### PR TITLE
Embedded envoy deployment + petstore app example

### DIFF
--- a/config/default/envoy_config_patch.yaml
+++ b/config/default/envoy_config_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: envoy
+        volumeMounts:
+        - name: envoy-config
+          mountPath: /etc/envoy/envoy.yaml
+          subPath: envoy-config.yaml
+      volumes:
+      - name: envoy-config
+        configMap:
+          name: envoy-config

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../envoy
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook
@@ -29,6 +30,8 @@ patchesStrategicMerge:
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
+
+- envoy_config_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/envoy/envoy-config.yaml
+++ b/config/envoy/envoy-config.yaml
@@ -1,0 +1,42 @@
+node:
+  cluster: default
+  id: default-1
+
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+  cds_config:
+    resource_api_version: V3
+    ads: {}
+  lds_config:
+    resource_api_version: V3
+    ads: {}
+
+static_resources:
+  clusters:
+  - type: STRICT_DNS
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    name: xds_cluster
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: kusk-xds-service.kusk-system.svc.cluster.local
+                port_value: 18000
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 19000

--- a/config/envoy/envoy.yaml
+++ b/config/envoy/envoy.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy
+  namespace: system
+  labels:
+    app: envoy
+spec:
+  selector:
+    matchLabels:
+      app: envoy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: envoy
+    spec:
+      containers:
+      - command:
+        - envoy
+        args:
+        - -c
+        - /etc/envoy/envoy.yaml
+        image: envoyproxy/envoy-dev:latest
+        name: envoy

--- a/config/envoy/kustomization.yaml
+++ b/config/envoy/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- envoy.yaml
+- service.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- files:
+  - envoy-config.yaml
+  name: envoy-config

--- a/config/envoy/service.yaml
+++ b/config/envoy/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-service
+  namespace: system
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: envoy

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- service.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/service.yaml
+++ b/config/manager/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: xds-service
+  namespace: system
+spec:
+  ports:
+    - port: 18000
+      name: xds
+      targetPort: xds
+  selector:
+    control-plane: controller-manager

--- a/config/samples/gateway_v1_api.yaml
+++ b/config/samples/gateway_v1_api.yaml
@@ -56,8 +56,8 @@ spec:
         - X-Custom-Header2
         max_age: 86200
       service:
-        name: petstore
-        port: 8080
+        name: petstore.default.svc.cluster.local
+        port: 80
       path:
         base: /petstore/api/v3
         trim_prefix: /petstore

--- a/examples/petstore/manifest.yaml
+++ b/examples/petstore/manifest.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: petstore
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app: petstore
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: petstore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: petstore
+  template:
+    metadata:
+      labels:
+        app: petstore
+    spec:
+      containers:
+        - name: service
+          image: swaggerapi/petstore3:unstable
+          ports:
+            - containerPort: 8080


### PR DESCRIPTION
Resolves #28.
Adds a kustomize-powered envoy deployment (deployable via `make deploy` alongside with the operator).