### PR TITLE
parser: proper nil checks and formatting

### DIFF
--- a/envoy/config/parser.go
+++ b/envoy/config/parser.go
@@ -29,13 +29,15 @@ func (e *envoyConfiguration) GenerateConfigSnapshotFromOpts(opts *options.Option
 		if err := copier.CopyWithOption(&pathOpts, &opts.SubOptions, copier.Option{IgnoreEmpty: true, DeepCopy: false}); err != nil {
 			return nil, err
 		}
-		pathSubOpts, _ := opts.PathSubOptions[path]
-		if err := copier.CopyWithOption(&pathOpts, &pathSubOpts, copier.Option{IgnoreEmpty: true, DeepCopy: false}); err != nil {
-			return nil, err
+
+		if pathSubOpts, ok := opts.PathSubOptions[path]; ok {
+			if err := copier.CopyWithOption(&pathOpts, &pathSubOpts, copier.Option{IgnoreEmpty: true, DeepCopy: false}); err != nil {
+				return nil, err
+			}
 		}
+
 		// x-kusk options per operation (http method)
 		for method := range pathItem.Operations() {
-
 			opSubOpts, ok := opts.OperationSubOptions[method+path]
 			if ok {
 				// Exit early if disabled per method, don't do further copies
@@ -45,14 +47,19 @@ func (e *envoyConfiguration) GenerateConfigSnapshotFromOpts(opts *options.Option
 			}
 
 			var finalOpts options.SubOptions
+
 			// copy into new var already merged path opts
 			if err := copier.CopyWithOption(&finalOpts, &pathOpts, copier.Option{IgnoreEmpty: true, DeepCopy: false}); err != nil {
 				return nil, err
 			}
-			// finally override with opSubOpts
-			if err := copier.CopyWithOption(&finalOpts, &opSubOpts, copier.Option{IgnoreEmpty: true, DeepCopy: false}); err != nil {
-				return nil, err
+
+			// finally override with opSubOpts, if there are any
+			if ok {
+				if err := copier.CopyWithOption(&finalOpts, &opSubOpts, copier.Option{IgnoreEmpty: true, DeepCopy: false}); err != nil {
+					return nil, err
+				}
 			}
+
 			// Once we have final merged Options, skip if disabled either on top, path or method level.
 			if finalOpts.Disabled != nil && *finalOpts.Disabled {
 				continue
@@ -66,6 +73,7 @@ func (e *envoyConfiguration) GenerateConfigSnapshotFromOpts(opts *options.Option
 			if err != nil {
 				return nil, err
 			}
+
 			if redirectAction != nil {
 				e.AddRouteRedirect(routeName, routePath, method, redirectAction)
 				// skip the rest of setup
@@ -77,11 +85,13 @@ func (e *envoyConfiguration) GenerateConfigSnapshotFromOpts(opts *options.Option
 			if !e.ClusterExist(clusterName) {
 				e.AddCluster(clusterName, finalOpts.Service.Name, finalOpts.Service.Port)
 			}
+
 			trimPrefixRegex := generateTrimPrefixRegex(finalOpts.Path.TrimPrefix)
 			corsPolicy, err := generateCORSPolicy(&finalOpts.CORS)
 			if err != nil {
 				return nil, err
 			}
+
 			e.AddRoute(
 				routeName,
 				routePath,
@@ -95,6 +105,7 @@ func (e *envoyConfiguration) GenerateConfigSnapshotFromOpts(opts *options.Option
 			)
 		}
 	}
+
 	return e.GenerateSnapshot()
 }
 


### PR DESCRIPTION
The actual panic was fixed in #dd77e8ff37dc22ee15170cff491428d2784c192e, but I've added some nil checks on map access.
It was working as intended because of `IgnoreEmpty` option in copier lib, but that code does look dangerous and further changes might cause it to break.

Resolves #54.