### PR TITLE
Add sorting of routes

### DIFF
--- a/controllers/api_controller.go
+++ b/controllers/api_controller.go
@@ -39,11 +39,6 @@ type APIReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the API object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *APIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/envoyfleet_controller.go
+++ b/controllers/envoyfleet_controller.go
@@ -41,11 +41,6 @@ type EnvoyFleetReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the EnvoyFleet object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *EnvoyFleetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/staticroute_controller.go
+++ b/controllers/staticroute_controller.go
@@ -40,11 +40,6 @@ type StaticRouteReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the StaticRoute object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *StaticRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/envoy/config/config.go
+++ b/envoy/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -157,6 +158,7 @@ func (e *envoyConfiguration) AddCluster(clusterName string, upstreamServiceHost 
 func (e *envoyConfiguration) makeRouteConfiguration(routeConfigName string) *route.RouteConfiguration {
 	vhosts := []*route.VirtualHost{}
 	for _, vhost := range e.vhosts {
+		vhost.Routes = sortRoutesByPathMatcher(vhost.Routes)
 		vhosts = append(vhosts, vhost)
 	}
 	return &route.RouteConfiguration{
@@ -182,4 +184,49 @@ func (e *envoyConfiguration) GenerateSnapshot() (*cache.Snapshot, error) {
 		return nil, err
 	}
 	return &snap, snap.Consistent()
+}
+
+// sortRoutesByPathMatcher creates route list ordered by:
+// * path matcher
+// * regex path matcher, longest regex path first
+// * prefix path matcher, longest path first
+// Envoy matches path by the first win in the routes order, so we need to be specific as possible.
+func sortRoutesByPathMatcher(routes []*route.Route) []*route.Route {
+	result := make([]*route.Route, 0, len(routes))
+	resultRegexPathsRoutes := []*route.Route{}
+	resultPrefixPathsRoutes := []*route.Route{}
+	for _, rt := range routes {
+		switch t := rt.Match.PathSpecifier.(type) {
+		case *route.RouteMatch_Path:
+			// We don't care if path is longer or shorter, path matcher will match correctly
+			result = append(result, rt)
+		case *route.RouteMatch_SafeRegex:
+			resultRegexPathsRoutes = append(resultRegexPathsRoutes, rt)
+		case *route.RouteMatch_Prefix:
+			resultPrefixPathsRoutes = append(resultPrefixPathsRoutes, rt)
+		default:
+			// We won't handle this as an error, this qualifies for a panic
+			panic(fmt.Sprintf("unsupported route path matcher type: %T", t))
+		}
+	}
+	// Sort by regex length, longest first.
+	// Note that this doesn't mean the regex will match the longest path exactly 100%, regex itself adds to the length to compare.
+	// However longer regex usually are more specific and should be prioritized.
+	sort.SliceStable(
+		resultRegexPathsRoutes,
+		func(i, j int) bool {
+			return len(resultRegexPathsRoutes[i].Match.GetSafeRegex().GetRegex()) > len(resultRegexPathsRoutes[j].Match.GetSafeRegex().GetRegex())
+		},
+	)
+	result = append(result, resultRegexPathsRoutes...)
+	// Sort by the path prefix length, longest first.
+	sort.SliceStable(
+		resultPrefixPathsRoutes,
+		func(i, j int) bool {
+			return len(resultPrefixPathsRoutes[i].Match.GetPrefix()) > len(resultPrefixPathsRoutes[j].Match.GetPrefix())
+		},
+	)
+	result = append(result, resultPrefixPathsRoutes...)
+
+	return result
 }


### PR DESCRIPTION
This PR...

## Changes

* adds sorting of routes by (exact path, regex, prefix) since Envoy chooses the first match in the list of routes.


## Fixes

* Routes order must be more specific #80

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
