### PR TITLE
Validation: fix API CRD to actually require spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,10 @@ run: install-local generate fmt vet ## Run a controller from your host, proxying
 	ktunnel expose -n kusk-system kusk-xds-service 18000 & ENABLE_WEBHOOKS=false bin/manager ; fg
 
 docker-build: ## Build docker image with the manager.
-	eval $(minikube docker-env --profile "kgw") && DOCKER_BUILDKIT=1 docker build -t ${IMG} .
+	DOCKER_BUILDKIT=1 docker build -t ${IMG} .
 
 docker-build-debug:## Build docker image with the manager and debugger.
-	eval $(minikube docker-env --profile "kgw") && DOCKER_BUILDKIT=1 docker build -t "${IMG}-debug" -f ./Dockerfile-debug .
+	DOCKER_BUILDKIT=1 docker build -t "${IMG}-debug" -f ./Dockerfile-debug .
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 

--- a/api/v1/api_types.go
+++ b/api/v1/api_types.go
@@ -54,7 +54,7 @@ type API struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   APISpec   `json:"spec,omitempty"`
+	Spec   APISpec   `json:"spec"`
 	Status APIStatus `json:"status,omitempty"`
 }
 

--- a/api/v1/api_webhook.go
+++ b/api/v1/api_webhook.go
@@ -88,7 +88,9 @@ func (r *API) validate() error {
 	if err != nil {
 		return fmt.Errorf("spec: should be a valid OpenAPI spec: %w", err)
 	}
-
+	if len(apiSpec.Paths) == 0 {
+		return fmt.Errorf("spec: should be a valid OpenAPI spec, no paths found")
+	}
 	opts, err := spec.GetOptions(apiSpec)
 	if err != nil {
 		return fmt.Errorf("spec: x-kusk should be a valid set of options: %w", err)

--- a/config/crd/bases/gateway.kusk.io_apis.yaml
+++ b/config/crd/bases/gateway.kusk.io_apis.yaml
@@ -45,6 +45,8 @@ spec:
           status:
             description: APIStatus defines the observed state of API
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true


### PR DESCRIPTION
Closes #85

Fixes validation, also checks that OpenAPI document Paths actually exists (empty OpenAPI is still valid doc).

Removes minikube overrides in Makefile since future developers might not be using it. Environment vars can be set separately with direnv if needed.