### PR TITLE
Edit typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ helm install kusk-gateway-default-envoyfleet kubeshop/kusk-gateway-envoyfleet -n
 
 [(Back to top)](#table-of-contents)
 
-Kusk Gateway configures itself via the [API CRD](docs/customeresources/api.md) that contains your embedded Swagger or OpenAPI document.
+Kusk Gateway configures itself via the [API CRD](docs/customresources/api.md) that contains your embedded Swagger or OpenAPI document.
 
 The easiest way to get started is to go through [ToDoMVC example](docs/todomvc.md).
 


### PR DESCRIPTION
Updated 404 link to API CRD doc in README.

This PR...

## Changes
-Link to API CRD under 'Usage' to correct page

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
