### PR TITLE
Upgrade to kubebuilder 3.2.0 tools

### DIFF
--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -90,9 +90,6 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = admissionv1beta1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
@@ -120,10 +117,9 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:webhook
 
 	go func() {
+		defer GinkgoRecover()
 		err = mgr.Start(ctx)
-		if err != nil {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(err).NotTo(HaveOccurred())
 	}()
 
 	// wait for the webhook server to get ready

--- a/config/crd/bases/gateway.kusk.io_apis.yaml
+++ b/config/crd/bases/gateway.kusk.io_apis.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: apis.gateway.kusk.io
 spec:

--- a/config/crd/bases/gateway.kusk.io_envoyfleet.yaml
+++ b/config/crd/bases/gateway.kusk.io_envoyfleet.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: envoyfleet.gateway.kusk.io
 spec:

--- a/config/crd/bases/gateway.kusk.io_staticroutes.yaml
+++ b/config/crd/bases/gateway.kusk.io_staticroutes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: staticroutes.gateway.kusk.io
 spec:


### PR DESCRIPTION
This PR...

\#\# Changes

Upgrades scaffolding to kubebuilder 3.2.0 tools, including controller\-gen to 0.7.0

\#\# Fixes

Removes not needed test line

Closes #139

\#\# Checklist

\- \[x\] tested locally
\- \[ \] added new dependencies
\- \[ \] updated the docs
\- \[ \] added a test
