### PR TITLE
Migrate from the deprecated github.com/golang/protobuf

### DIFF
--- a/envoy/config/config.go
+++ b/envoy/config/config.go
@@ -6,7 +6,6 @@ package config
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -17,7 +16,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/gofrs/uuid"
-	"github.com/golang/protobuf/ptypes"
+
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // Simplified objects hierarchy configuration as for the static Envoy config
@@ -147,7 +147,7 @@ func (e *envoyConfiguration) AddCluster(clusterName string, upstreamServiceHost 
 
 	e.clusters[clusterName] = &cluster.Cluster{
 		Name:                 clusterName,
-		ConnectTimeout:       ptypes.DurationProto(5 * time.Second),
+		ConnectTimeout:       &durationpb.Duration{Seconds: 5},
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_LOGICAL_DNS},
 		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
 		LoadAssignment:       upstreamEndpoint,

--- a/envoy/config/config_routines.go
+++ b/envoy/config/config_routines.go
@@ -17,7 +17,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -338,7 +337,7 @@ func generateRoute(
 	if retries != 0 {
 		routeRoute.Route.RetryPolicy = &route.RetryPolicy{
 			RetryOn:    "5xx",
-			NumRetries: &wrappers.UInt32Value{Value: retries},
+			NumRetries: &wrapperspb.UInt32Value{Value: retries},
 		}
 	}
 	if err := routeRoute.Route.Validate(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/gofrs/uuid v4.0.0+incompatible
-	github.com/golang/protobuf v1.5.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
This PR...

## Changes

Migration from the deprecated github.com/golang/protobuf package to google.golang.org/protobuf

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
