### PR TITLE
Add externalTrafficPolicy handling

### DIFF
--- a/api/v1alpha1/envoyfleet_types.go
+++ b/api/v1alpha1/envoyfleet_types.go
@@ -94,6 +94,18 @@ type ServiceConfig struct {
 	// Static ip address for the LoadBalancer type if available
 	// +optional
 	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
+
+	// externalTrafficPolicy denotes if this Service desires to route external
+	// traffic to node-local or cluster-wide endpoints. "Local" preserves the
+	// client source IP and avoids a second hop for LoadBalancer and Nodeport
+	// type services, but risks potentially imbalanced traffic spreading.
+	// "Cluster" obscures the client source IP and may cause a second hop to
+	// another node, but should have good overall load-spreading.
+	// +optional
+	// For the preservation of the real client ip in access logs chose "Local"
+	// +optional
+	// +kubebuilder:validation:Enum=Cluster;Local
+	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
 }
 
 // AccessLoggingConfig defines the access logs Envoy logging settings

--- a/api/v1alpha1/envoyfleet_types.go
+++ b/api/v1alpha1/envoyfleet_types.go
@@ -101,7 +101,6 @@ type ServiceConfig struct {
 	// type services, but risks potentially imbalanced traffic spreading.
 	// "Cluster" obscures the client source IP and may cause a second hop to
 	// another node, but should have good overall load-spreading.
-	// +optional
 	// For the preservation of the real client ip in access logs chose "Local"
 	// +optional
 	// +kubebuilder:validation:Enum=Cluster;Local

--- a/config/crd/bases/gateway.kusk.io_envoyfleet.yaml
+++ b/config/crd/bases/gateway.kusk.io_envoyfleet.yaml
@@ -941,6 +941,19 @@ spec:
                       type: string
                     description: Service's annotations
                     type: object
+                  externalTrafficPolicy:
+                    description: externalTrafficPolicy denotes if this Service desires
+                      to route external traffic to node-local or cluster-wide endpoints.
+                      "Local" preserves the client source IP and avoids a second hop
+                      for LoadBalancer and Nodeport type services, but risks potentially
+                      imbalanced traffic spreading. "Cluster" obscures the client
+                      source IP and may cause a second hop to another node, but should
+                      have good overall load-spreading. For the preservation of the
+                      real client ip in access logs chose "Local"
+                    enum:
+                    - Cluster
+                    - Local
+                    type: string
                   loadBalancerIP:
                     description: Static ip address for the LoadBalancer type if available
                     type: string

--- a/config/samples/gateway_v1_envoyfleet.yaml
+++ b/config/samples/gateway_v1_envoyfleet.yaml
@@ -19,6 +19,10 @@ spec:
     - name: https
       port: 443
       targetPort: https
+    # To preserve clients real ip addresses choose Local.
+    # Note that this can make load balancing worse.
+    #externalTrafficPolicy: Cluster|Local
+    #externalTrafficPolicy: Local
   resources:
     # limits:
     #   cpu: 1

--- a/controllers/envoyfleet_resources.go
+++ b/controllers/envoyfleet_resources.go
@@ -259,6 +259,9 @@ func (e *EnvoyFleetResources) generateService() {
 	if e.fleet.Spec.Service.Type == corev1.ServiceTypeLoadBalancer && e.fleet.Spec.Service.LoadBalancerIP != "" {
 		e.service.Spec.LoadBalancerIP = e.fleet.Spec.Service.LoadBalancerIP
 	}
+	if e.fleet.Spec.Service.ExternalTrafficPolicy != "" {
+		e.service.Spec.ExternalTrafficPolicy = e.fleet.Spec.Service.ExternalTrafficPolicy
+	}
 
 	return
 }


### PR DESCRIPTION
This PR...

## Changes

Adds specifying of ExternalTrafficPolicy for the service to preserve clients ip addresses.

## Fixes

Closes #164

Documentation update in #144

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
