### PR TITLE
log out object names when processing instead of whole objects

### DIFF
--- a/controllers/config_manager.go
+++ b/controllers/config_manager.go
@@ -85,7 +85,7 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 
 	parser := spec.NewParser(nil)
 	for _, api := range apis {
-		l.Info("Processing API configuration", "fleet", fleetIDstr, "api", api)
+		l.Info("Processing API configuration", "fleet", fleetIDstr, "api", api.Name)
 		apiSpec, err := parser.ParseFromReader(strings.NewReader(api.Spec.Spec))
 		if err != nil {
 			return fmt.Errorf("failed to parse OpenAPI spec: %w", err)
@@ -103,7 +103,7 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 		if err = UpdateConfigFromAPIOpts(envoyConfig, opts, apiSpec); err != nil {
 			return fmt.Errorf("failed to generate config: %w", err)
 		}
-		l.Info("API route configuration processed", "fleet", fleetIDstr, "api", api)
+		l.Info("API route configuration processed", "fleet", fleetIDstr, "api", api.Name)
 	}
 
 	l.Info("Succesfully processed APIs", "fleet", fleetIDstr)
@@ -114,7 +114,7 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 		return err
 	}
 	for _, sr := range staticRoutes {
-		l.Info("Processing static routes", "fleet", fleetIDstr, "route", sr)
+		l.Info("Processing static routes", "fleet", fleetIDstr, "route", sr.Name)
 		opts, err := sr.Spec.GetOptionsFromSpec()
 		if err != nil {
 			return fmt.Errorf("failed to generate options from the static route config: %w", err)


### PR DESCRIPTION
log out object names when processing instead of whole objects which are unreadable. In future we should configure log levels that will output objects in full but printed prettily

This PR closes #185

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
