### PR TITLE
Replace Unmarshal with UnmarshalStrict when parsing x-kusk extension

### DIFF
--- a/spec/extension.go
+++ b/spec/extension.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kubeshop/kusk-gateway/options"
 )
@@ -67,7 +67,7 @@ func GetOptions(spec *openapi3.T) (*options.Options, error) {
 func parseExtension(extensionProps *openapi3.ExtensionProps, target interface{}) (bool, error) {
 	if extension, ok := extensionProps.Extensions[kuskExtensionKey]; ok {
 		if kuskExtension, ok := extension.(json.RawMessage); ok {
-			err := yaml.Unmarshal(kuskExtension, target)
+			err := yaml.UnmarshalStrict(kuskExtension, target)
 			if err != nil {
 				return false, fmt.Errorf("failed to parse extension: %w", err)
 			}

--- a/spec/extension_test.go
+++ b/spec/extension_test.go
@@ -17,6 +17,7 @@ func TestGetOptions(t *testing.T) {
 		name string
 		spec *openapi3.T
 		res  options.Options
+		err  bool
 	}{
 		{
 			name: "no extensions",
@@ -70,6 +71,23 @@ func TestGetOptions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "operation level options set",
+			spec: &openapi3.T{
+				Paths: openapi3.Paths{
+					"/pet": &openapi3.PathItem{
+						Put: &openapi3.Operation{
+							ExtensionProps: openapi3.ExtensionProps{
+								Extensions: map[string]interface{}{
+									kuskExtensionKey: json.RawMessage(`{"enabled":true}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			err: true,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -77,8 +95,11 @@ func TestGetOptions(t *testing.T) {
 			r := require.New(t)
 
 			actual, err := GetOptions(testCase.spec)
-			r.NoError(err, "failed to get options")
-			r.Equal(testCase.res, *actual)
+			if testCase.err {
+				r.True(err != nil, "expected error")
+			} else {
+				r.Equal(testCase.res, *actual)
+			}
 		})
 	}
 


### PR DESCRIPTION
This is so parsing fails if there are fields present that are not support in x-kusk

This PR closes #200 
This PR closes #192 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
