### PR TITLE
Set up Kubernetes v1.Secret informer to notify manager on change to

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -217,11 +217,12 @@ func main() {
 	secretsChan := make(chan *corev1.Secret)
 
 	controllerConfigManager := controllers.KubeEnvoyConfigManager{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		EnvoyManager: envoyManager,
-		Validator:    proxy,
-		SecretsChan:  secretsChan,
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		EnvoyManager:       envoyManager,
+		Validator:          proxy,
+		WatchedSecretsChan: secretsChan,
+		SecretToEnvoyFleet: map[string]gateway.EnvoyFleetID{},
 	}
 
 	if err = (&controllers.EnvoyFleetReconciler{

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -114,7 +114,7 @@ func initSecretsInformer(
 
 	dynamicConfig := dynamic.NewForConfigOrDie(config)
 	resource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
-	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicConfig, time.Minute, corev1.NamespaceAll, nil)
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicConfig, time.Minute)
 	informer := factory.ForResource(resource).Informer()
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -135,6 +135,7 @@ func initSecretsInformer(
 			oldSecret, err := parseSecret(oldU)
 			if err != nil {
 				log.Error(err, "unable to parse old secret")
+				return
 			}
 
 			if reflect.DeepEqual(oldSecret.Data, newSecret.Data) {


### PR DESCRIPTION
Set up Kubernetes v1.Secret informer to notify manager on change tosecrets. KubeEnvoyConfigManager will then refresh the envoy configuration for the envoy fleet is the secret that was updated is referenced in the envoyfleet configuration

This PR closes #188 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
