### PR TITLE
Auto Redirect to HTTPS - Set VirtualHost TLS Setting from EnvoyFleet [2/2]

### DIFF
--- a/internal/controllers/config_manager.go
+++ b/internal/controllers/config_manager.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -143,6 +144,15 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 	if err := c.Client.Get(ctx, types.NamespacedName{Name: fleetID.Name, Namespace: fleetID.Namespace}, &fleet); err != nil {
 		l.Error(err, "Failed to get Envoy Fleet", "fleet", fleetIDstr)
 		return fmt.Errorf("failed to get Envoy Fleet %s: %w", fleetIDstr, err)
+	}
+
+	// Set TLS Requirement for all virtual hosts managed by EnvoyFleet based on Requirement setting
+	// in EnvoyFleet.TLS settings
+	envoyTLSRequirement := envoy_config_route_v3.VirtualHost_TlsRequirementType(
+		envoy_config_route_v3.VirtualHost_TlsRequirementType_value[fleet.Spec.TLS.Requirement],
+	)
+	for _, vh := range envoyConfig.GetVirtualHosts() {
+		vh.RequireTls = envoyTLSRequirement
 	}
 
 	httpConnectionManagerBuilder := config.NewHCMBuilder()


### PR DESCRIPTION
Set TLS requirement setting for each virtual host managed by the envoyfleet based on the requirement setting set in the EnvoyFleet resource

This PR closes #181 


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
