### PR TITLE
Handling Mocking media types

### DIFF
--- a/development/testing/manifests/api.yaml
+++ b/development/testing/manifests/api.yaml
@@ -212,6 +212,18 @@ spec:
                       completed: true
                       order: 13
                       url: "http://mockedURL.com"
+                text/plain:
+                  example: |
+                    title: "Mocked title with text example
+                    completed: true
+                    order: 13
+                    url: "http://mockedURL.com"
+                application/xml:
+                  example:
+                    title: "Mocked title with XML example"
+                    completed: true
+                    order: 13
+                    url: "http://mockedURL.com"
             '400':
               description: Client error
               content:

--- a/development/testing/manifests/api.yaml
+++ b/development/testing/manifests/api.yaml
@@ -277,7 +277,19 @@ spec:
                       - url
                   # This example is the must for the response body mocking
                   example:
-                    title: "Mocked title"
+                    title: "Mocked JSON title"
+                    completed: true
+                    order: 13
+                    url: "http://mockedURL.com"
+                application/xml:
+                  example:
+                    title: "Mocked XML title"
+                    completed: true
+                    order: 13
+                    url: "http://mockedURL.com"
+                text/plain:
+                  example: |
+                    title: "Mocked Text title"
                     completed: true
                     order: 13
                     url: "http://mockedURL.com"

--- a/development/testing/postman/api.postman_collection.json
+++ b/development/testing/postman/api.postman_collection.json
@@ -790,7 +790,7 @@
 									"    pm.expect(jsonData).to.be.an(\"object\");",
 									"    pm.expect(pm.response.headers.get('content-type')).to.eql('application/json');",
 									"    pm.expect(pm.response.headers.get('x-kusk-mocked')).to.eql('true');",
-									"    pm.expect(jsonData.title).to.eql(\"Mocked title\");",
+									"    pm.expect(jsonData.title).to.eql(\"Mocked JSON title\");",
 									"    pm.expect(jsonData.order).to.eql(13);",
 									"    pm.expect(jsonData.completed).to.eql(true);",
 									"}",

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -389,7 +389,7 @@ Note: currently `mocking` is incompatible with the `validation` option, the conf
         ...
 ```
 
-With the example above the response to GET request will be different depending on the client's preffered media type when using the Accept header.
+With the example above, the response to GET request will be different depending on the client's preferred media type when using the `Accept` header.
 
 Below we're using the example.com setup from the development/testing directory.
 

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -271,6 +271,7 @@ The validation objects contains the following properties to configure automatic 
 | validation.request.enabled | boolean flag to enable request validation |
 
 #### strict validation of request bodies
+
 Strict validation means that the request body must conform exactly to the schema specified in your openapi spec.
 Any fields not in schema will cause the validation to fail the request/response.
 To enable this, please add the following field to your schema block if the request body is of type `object`
@@ -368,6 +369,18 @@ Note: currently `mocking` is incompatible with the `validation` option, the conf
                       completed: true
                       order: 13
                       url: "http://mockedURL.com"
+                application/xml:
+                  example:
+                    title: "Mocked XML title"
+                    completed: true
+                    order: 13
+                    url: "http://mockedURL.com"
+                text/plain:
+                  example: |
+                    title: "Mocked Text title"
+                    completed: true
+                    order: 13
+                    url: "http://mockedURL.com"
         patch:
           # Disable for patch
           x-kusk:
@@ -378,7 +391,10 @@ Note: currently `mocking` is incompatible with the `validation` option, the conf
 
 With the example above the response to GET request will be:
 
+1. Curl call without specifying Accept header - uses the first media type specified in the spec (application/json):
+
 ```shell
+
 < HTTP/1.1 200 OK
 < content-type: application/json
 < x-kusk-mocked: true
@@ -391,3 +407,5 @@ With the example above the response to GET request will be:
 ```
 
 The response includes the `x-kusk-mocked: true` header indicating mocking.
+
+2. With Accept header:

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/clbanning/mxj v1.8.4
 	github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
+github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/agent/httpserver/negotiator.go
+++ b/internal/agent/httpserver/negotiator.go
@@ -156,8 +156,8 @@ func negotiateContentType(accepts []AcceptRange, offers []AcceptRange, defaultOf
 			if bestWeight > (accept.Weight + booster) {
 				continue // we already have something better..
 			} else if accept.Type == "*" && accept.Subtype == "*" {
-				best = offer.RawString()
-				bestWeight = accept.Weight + booster
+				// If no preference specified - skip to use the default
+				continue
 			} else if accept.Subtype == "*" && offer.Type == accept.Type {
 				best = offer.RawString()
 				bestWeight = accept.Weight + booster

--- a/internal/agent/httpserver/negotiator.go
+++ b/internal/agent/httpserver/negotiator.go
@@ -1,0 +1,176 @@
+// This file was copied from go-ozzo/ozzo-routing
+// The goal is to do the Accept header parsing for the ContentType negotiation.
+
+package httpserver
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// AcceptRange represents an accept range as defined in https://tools.ietf.org/html/rfc7231#section-5.3.2
+//
+// Accept = #( media-range [ accept-params ] )
+//  media-range    = ( "*/*"
+//                   / ( type "/" "*" )
+//                   / ( type "/" subtype )
+//                   ) *( OWS ";" OWS parameter )
+//  accept-params  = weight *( accept-ext )
+//  accept-ext = OWS ";" OWS token [ "=" ( token / quoted-string ) ]
+type AcceptRange struct {
+	Type       string
+	Subtype    string
+	Weight     float64
+	Parameters map[string]string
+	raw        string // the raw string for this accept
+}
+
+// RawString returns the raw string in the request specifying the accept range.
+func (a AcceptRange) RawString() string {
+	return a.raw
+}
+
+// AcceptMediaTypes builds a list of AcceptRange from the given HTTP request.
+func AcceptMediaTypes(r *http.Request) []AcceptRange {
+	result := []AcceptRange{}
+
+	for _, v := range r.Header["Accept"] {
+		result = append(result, ParseAcceptRanges(v)...)
+	}
+
+	return result
+}
+
+// ParseAcceptRanges parses an Accept header into a list of AcceptRange
+func ParseAcceptRanges(accepts string) []AcceptRange {
+	result := []AcceptRange{}
+	remaining := accepts
+	for {
+		var accept string
+		accept, remaining = extractFieldAndSkipToken(remaining, ',')
+		result = append(result, ParseAcceptRange(accept))
+		if len(remaining) == 0 {
+			break
+		}
+	}
+	return result
+}
+
+// ParseAcceptRange parses a single accept string into an AcceptRange.
+func ParseAcceptRange(accept string) AcceptRange {
+	typeAndSub, rawparams := extractFieldAndSkipToken(accept, ';')
+
+	tp, subtp := extractFieldAndSkipToken(typeAndSub, '/')
+	params := extractParams(rawparams)
+
+	w := extractWeight(params)
+	return AcceptRange{Type: tp, Subtype: subtp, Parameters: params, Weight: w, raw: accept}
+}
+
+func extractWeight(params map[string]string) float64 {
+	if w, ok := params["q"]; ok {
+		res, err := strconv.ParseFloat(w, 64)
+		if err == nil {
+			return res
+		}
+	}
+	return 1 // default is 1
+}
+
+func extractParams(raw string) map[string]string {
+	params := map[string]string{}
+	rest := raw
+	for {
+		var p string
+		p, rest = extractFieldAndSkipToken(rest, ';')
+		if len(p) > 0 {
+			k, v := extractFieldAndSkipToken(p, '=')
+			params[k] = v
+		}
+		if len(rest) == 0 {
+			break
+		}
+	}
+
+	return params
+}
+
+func extractFieldAndSkipToken(s string, sep rune) (string, string) {
+	f, r := extractField(s, sep)
+	if len(r) > 0 {
+		r = r[1:]
+	}
+	return f, r
+}
+
+func extractField(s string, sep rune) (field, rest string) {
+	field = s
+	for i, v := range s {
+		if v == sep {
+			field = strings.TrimSpace(s[:i])
+			rest = strings.TrimSpace(s[i:])
+			break
+		}
+	}
+	return
+}
+
+func compareParams(params1 map[string]string, params2 map[string]string) (count int) {
+	for k1, v1 := range params1 {
+		if v2, ok := params2[k1]; ok && v1 == v2 {
+			count++
+		}
+	}
+	return count
+}
+
+// NegotiateContentType negotiates the content types based on the given request and allowed types.
+func NegotiateContentType(r *http.Request, offers []string, defaultOffer string) string {
+	accepts := AcceptMediaTypes(r)
+	offerRanges := []AcceptRange{}
+	for _, off := range offers {
+		offerRanges = append(offerRanges, ParseAcceptRange(off))
+	}
+
+	return negotiateContentType(accepts, offerRanges, ParseAcceptRange(defaultOffer))
+}
+
+func negotiateContentType(accepts []AcceptRange, offers []AcceptRange, defaultOffer AcceptRange) string {
+	best := defaultOffer.RawString()
+	bestWeight := float64(0)
+	bestParams := 0
+
+	for _, offer := range offers {
+		for _, accept := range accepts {
+			// add a booster on the weights to prefer more exact matches to wildcards
+			// such that: */* = 0, x/* = 1, x/x = 2
+			booster := float64(0)
+			if accept.Type != "*" {
+				booster++
+				if accept.Subtype != "*" {
+					booster++
+				}
+			}
+
+			if bestWeight > (accept.Weight + booster) {
+				continue // we already have something better..
+			} else if accept.Type == "*" && accept.Subtype == "*" {
+				best = offer.RawString()
+				bestWeight = accept.Weight + booster
+			} else if accept.Subtype == "*" && offer.Type == accept.Type {
+				best = offer.RawString()
+				bestWeight = accept.Weight + booster
+			} else if accept.Type == offer.Type && accept.Subtype == offer.Subtype {
+				paramCount := compareParams(accept.Parameters, offer.Parameters)
+				if paramCount >= bestParams { // if it's equal this one must be better, since the weight was better..
+					best = offer.RawString()
+					bestWeight = accept.Weight + booster
+					bestParams = paramCount
+				}
+			}
+		}
+	}
+
+	return best
+}

--- a/internal/agent/httpserver/negotiator_test.go
+++ b/internal/agent/httpserver/negotiator_test.go
@@ -1,0 +1,119 @@
+// This file was copied from go-ozzo/ozzo-routing
+package httpserver
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentNegotiation(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;q=1;v=1")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "application/json;v=1", format)
+}
+
+func TestContentNegotiation2(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;q=0.6;v=1,application/json;v=2")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "application/json;v=2", format)
+}
+
+func TestContentNegotiation3(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "*/*,application/xml")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "application/xml", format)
+}
+
+func TestContentNegotiation4(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "*/*")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml"}
+	format := NegotiateContentType(req, offers, "application/json")
+	assert.Equal(t, "application/json", format)
+}
+
+func TestContentNegotiation5(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "*/*")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "text/html", format)
+}
+func TestAccept(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;  q=1 ; v=1,")
+	req := &http.Request{Header: header}
+	mtypes := AcceptMediaTypes(req)
+
+	assert.Equal(t, float64(1), mtypes[0].Weight)
+	assert.Equal(t, "application", mtypes[0].Type)
+	assert.Equal(t, "json", mtypes[0].Subtype)
+	assert.Equal(t, map[string]string{"v": "1", "q": "1"}, mtypes[0].Parameters)
+}
+
+func TestAcceptMultiple(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;q=1;v=1, application/json;v=2,   text/html")
+	req := &http.Request{Header: header}
+
+	mtypes := AcceptMediaTypes(req)
+
+	assert.Equal(t, float64(1), mtypes[0].Weight)
+	assert.Equal(t, "application", mtypes[0].Type)
+	assert.Equal(t, "json", mtypes[0].Subtype)
+	assert.Equal(t, map[string]string{"v": "1", "q": "1"}, mtypes[0].Parameters)
+
+	assert.Equal(t, float64(1), mtypes[1].Weight)
+	assert.Equal(t, "application", mtypes[1].Type)
+	assert.Equal(t, "json", mtypes[1].Subtype)
+	assert.Equal(t, map[string]string{"v": "2"}, mtypes[1].Parameters)
+
+	assert.Equal(t, float64(1), mtypes[2].Weight)
+	assert.Equal(t, "text", mtypes[2].Type)
+	assert.Equal(t, "html", mtypes[2].Subtype)
+	assert.Equal(t, map[string]string{}, mtypes[2].Parameters)
+}
+
+func TestAcceptElaborate(t *testing.T) {
+	a := `text/plain; q=0.5, text/html, 
+          text/x-dvi; q=0.8, text/x-c`
+
+	header := http.Header{}
+	header.Set("Accept", a)
+	req := &http.Request{Header: header}
+	mtypes := AcceptMediaTypes(req)
+
+	assert.Equal(t, float64(0.5), mtypes[0].Weight)
+	assert.Equal(t, "text", mtypes[0].Type)
+	assert.Equal(t, "plain", mtypes[0].Subtype)
+
+	assert.Equal(t, float64(1), mtypes[1].Weight)
+	assert.Equal(t, "text", mtypes[1].Type)
+	assert.Equal(t, "html", mtypes[1].Subtype)
+
+	assert.Equal(t, float64(0.8), mtypes[2].Weight)
+	assert.Equal(t, "text", mtypes[2].Type)
+	assert.Equal(t, "x-dvi", mtypes[2].Subtype)
+
+	assert.Equal(t, float64(1), mtypes[3].Weight)
+	assert.Equal(t, "text", mtypes[3].Type)
+	assert.Equal(t, "x-c", mtypes[3].Subtype)
+}

--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -112,7 +112,7 @@ func UpdateConfigFromAPIOpts(envoyConfiguration *config.EnvoyConfiguration, mock
 					return fmt.Errorf("mocking and validation are enabled but are mutually exclusive")
 				}
 
-				clusterName := "MockingService"
+				clusterName := "AgentHTTPService"
 				if !envoyConfiguration.ClusterExist(clusterName) {
 					envoyConfiguration.AddCluster(clusterName, agentHTTPServer.ServerHostname, agentHTTPServer.ServerPort)
 				}


### PR DESCRIPTION
This PR...

## Changes

Adds handling of multiple media types for the Mocking, depending on Accept header that client specifies. If no Accept header specified, used the application/json if it is present in the list or the first in the list if not.

## Fixes

Closes #231

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
