### PR TITLE
Remove kgw-envoy prefix

### DIFF
--- a/api/v1alpha1/envoyfleet_webhook.go
+++ b/api/v1alpha1/envoyfleet_webhook.go
@@ -48,8 +48,6 @@ var (
 const (
 	EnvoyFleetMutatingWebhookPath   string = "/mutate-gateway-kusk-io-v1alpha1-envoyfleet"
 	EnvoyFleetValidatingWebhookPath        = "/validate-gateway-kusk-io-v1alpha1-envoyfleet"
-
-	EnvoyResourceNamePrefix = "kgw-envoy-"
 )
 
 //+kubebuilder:webhook:path=/mutate-gateway-kusk-io-v1alpha1-envoyfleet,mutating=true,failurePolicy=fail,sideEffects=None,groups=gateway.kusk.io,resources=envoyfleet,verbs=create;update,versions=v1alpha1,name=menvoyfleet.kb.io,admissionReviewVersions=v1
@@ -132,7 +130,7 @@ func (e *EnvoyFleetValidator) validate(ctx context.Context, envoyFleet *EnvoyFle
 }
 
 func (e *EnvoyFleetValidator) validateNameWithinSizeBound(name string) admission.Response {
-	if kubernetesMaxNameLength := 64; len(EnvoyResourceNamePrefix+name) > kubernetesMaxNameLength {
+	if kubernetesMaxNameLength := 64; len(name) > kubernetesMaxNameLength {
 		err := fmt.Errorf(
 			"resulting name of envoy resources (%s) is larger than the kubernetes max allowed name of %d",
 			name,

--- a/docs/local-installation.md
+++ b/docs/local-installation.md
@@ -108,7 +108,7 @@ Run this to find out the External IP address of EnvoyFleet Load balancer.
 kubectl get svc -l "app.kubernetes.io/part-of=kusk-gateway,app.kubernetes.io/component=envoy-svc" --namespace kusk-system
 ```
 
-The output should contain the Service **kgw-envoy-kusk-gateway-envoyfleet** with the **External-IP** address field - use this address for your API endpoints querying.
+The output should contain the Service **kusk-gateway-envoyfleet** with the **External-IP** address field - use this address for your API endpoints querying.
 
 You can now deploy your API or Front applications to this cluster and configure access to them with [Custom Resources](customresources/index.md) or you can check the [ToDoMVC Example](todomvc.md) for the guidelines on how to do this.
 

--- a/internal/controllers/envoyfleet_resources.go
+++ b/internal/controllers/envoyfleet_resources.go
@@ -84,7 +84,7 @@ func (e *EnvoyFleetResources) generateConfigMap(ctx context.Context) error {
 		labels[key] = value
 	}
 
-	configMapName := gateway.EnvoyResourceNamePrefix + e.fleet.Name
+	configMapName := e.fleet.Name
 
 	xdsLabels := map[string]string{"app.kubernetes.io/name": "kusk-gateway", "app.kubernetes.io/component": "xds-service"}
 	xdsServices, err := k8sutils.GetServicesByLabels(ctx, e.client, xdsLabels)
@@ -130,7 +130,7 @@ func (e *EnvoyFleetResources) generateDeployment(ctx context.Context) error {
 		labels[key] = value
 	}
 
-	deploymentName := gateway.EnvoyResourceNamePrefix + e.fleet.Name
+	deploymentName := e.fleet.Name
 
 	configMapName := e.configMap.Name
 
@@ -310,7 +310,7 @@ func (e *EnvoyFleetResources) generateService() {
 	for key, value := range e.sharedLabels {
 		labels[key] = value
 	}
-	serviceName := gateway.EnvoyResourceNamePrefix + e.fleet.Name
+	serviceName := e.fleet.Name
 
 	e.service = &corev1.Service{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
This PR removes `kgw-envoy` as prefix, so we can keep consistency in all deployment/services namings

See below what's currently created 

![image](https://user-images.githubusercontent.com/27779735/161723345-83635b22-1cfb-41b1-a484-b302910c8830.png)


## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
