### PR TITLE
added Google Analytics v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$(ANALYTICS_TRACKING_ID) -X github.com/kubeshop/testkube/pkg/analytics.kuskGAApiSecret=$(ANALYTICS_API_KEY)
+LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$(ANALYTICS_TRACKING_ID) -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAApiSecret=$(ANALYTICS_API_KEY)
 
 .PHONY: all
 all: build

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$(ANALYTICS_TRACKING_ID) -X github.com/kubeshop/testkube/pkg/analytics.kuskGAApiSecret=$(ANALYTICS_API_KEY)
+
 .PHONY: all
 all: build
 
@@ -93,8 +95,8 @@ docker-images-cache: ## Saves locally frequently used container images and uploa
 
 .PHONY: build
 build: generate fmt vet ## Build manager and agent binary.
-	go build -o bin/manager cmd/manager/main.go
-	go build -o bin/agent cmd/agent/main.go
+	go build -o bin/manager -ldflags='$(LD_FLAGS)' cmd/manager/main.go 
+	go build -o bin/agent -ldflags='$(LD_FLAGS)' cmd/agent/main.go
 
 .PHONY: run
 run: install-local generate fmt vet ## Run a controller from your host, proxying it inside the cluster.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$(ANALYTICS_TRACKING_ID) -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAApiSecret=$(ANALYTICS_API_KEY)
+LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/analytics.KuskGAMeasurementID=$(ANALYTICS_TRACKING_ID) -X github.com/kubeshop/kusk-gateway/pkg/analytics.KuskGAApiSecret=$(ANALYTICS_API_KEY)
 
 .PHONY: all
 all: build

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -18,7 +18,7 @@ ARG ANALYTICS_API_KEY
 ARG ANALYTICS_TRACKING_ID 
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o agent cmd/agent/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.KuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/kusk-gateway/pkg/analytics.KuskGAApiSecret=$ANALYTICS_API_KEY" -o agent cmd/agent/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -18,7 +18,7 @@ ARG ANALYTICS_API_KEY
 ARG ANALYTICS_TRACKING_ID 
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/testkube/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o agent cmd/agent/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o agent cmd/agent/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -14,8 +14,11 @@ RUN go mod download
 # Copy the go source
 COPY . .
 
+ARG ANALYTICS_API_KEY 
+ARG ANALYTICS_TRACKING_ID 
+
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o agent cmd/agent/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/testkube/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o agent cmd/agent/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build/manager/Dockerfile
+++ b/build/manager/Dockerfile
@@ -11,11 +11,14 @@ ARG GOPROXY
 ENV GOPROXY=$GOPROXY
 RUN go mod download
 
+ARG ANALYTICS_API_KEY 
+ARG ANALYTICS_TRACKING_ID 
+
 # Copy the go source
 COPY . .
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -v -o manager cmd/manager/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/testkube/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o manager cmd/manager/main.go
 
 # Directory for the files created and used by the manager, to be copied for static rootless images since we don't have shell to create it there
 RUN mkdir -m=00755 /opt/manager

--- a/build/manager/Dockerfile
+++ b/build/manager/Dockerfile
@@ -18,7 +18,7 @@ ARG ANALYTICS_TRACKING_ID
 COPY . .
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/testkube/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o manager cmd/manager/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o manager cmd/manager/main.go
 
 # Directory for the files created and used by the manager, to be copied for static rootless images since we don't have shell to create it there
 RUN mkdir -m=00755 /opt/manager

--- a/build/manager/Dockerfile
+++ b/build/manager/Dockerfile
@@ -18,7 +18,7 @@ ARG ANALYTICS_TRACKING_ID
 COPY . .
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAApiSecret=$ANALYTICS_API_KEY" -o manager cmd/manager/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.KuskGAMeasurementID=$ANALYTICS_TRACKING_ID -X github.com/kubeshop/kusk-gateway/pkg/analytics.KuskGAApiSecret=$ANALYTICS_API_KEY" -o manager cmd/manager/main.go
 
 # Directory for the files created and used by the manager, to be copied for static rootless images since we don't have shell to create it there
 RUN mkdir -m=00755 /opt/manager

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kubeshop/kusk-gateway/internal/agent/httpserver"
 	"github.com/kubeshop/kusk-gateway/internal/agent/management"
+	"github.com/kubeshop/kusk-gateway/pkg/analytics"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -18,6 +19,7 @@ import (
 )
 
 func main() {
+	analytics.SendAnonymousInfo("envoyfleet agent sidecar bootstraping")
 
 	var (
 		agentConfigurationManagerServiceAddress string

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -207,7 +207,7 @@ func initWebhookCerts(ctx context.Context, webhookCertsDir string, webhookServer
 }
 
 func main() {
-	analytics.SendAnonymousInfo("kusk-gateway manager bootstraping")
+	analytics.SendAnonymousInfo("kusk-gateway manager bootstrapping")
 	logger, err := initLogger(false, config.LogLevel)
 	if err != nil {
 		_ = fmt.Errorf("unable to init logger: %w", err)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -63,6 +63,7 @@ import (
 	"github.com/kubeshop/kusk-gateway/internal/envoy/manager"
 	"github.com/kubeshop/kusk-gateway/internal/validation"
 	"github.com/kubeshop/kusk-gateway/internal/webhooks"
+	"github.com/kubeshop/kusk-gateway/pkg/analytics"
 )
 
 var (
@@ -206,6 +207,7 @@ func initWebhookCerts(ctx context.Context, webhookCertsDir string, webhookServer
 }
 
 func main() {
+	analytics.SendAnonymousInfo("kusk-gateway manager bootstraping")
 	logger, err := initLogger(false, config.LogLevel)
 	if err != nil {
 		_ = fmt.Errorf("unable to init logger: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/kubeshop/kusk-gateway
 go 1.17
 
 require (
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/envoyproxy/go-control-plane v0.10.1
 	github.com/getkin/kin-openapi v0.76.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
@@ -23,7 +25,6 @@ require (
 require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/internal/controllers/api_controller.go
+++ b/internal/controllers/api_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	gateway "github.com/kubeshop/kusk-gateway/api/v1alpha1"
+	"github.com/kubeshop/kusk-gateway/pkg/analytics"
 )
 
 const (
@@ -58,6 +59,7 @@ type APIReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *APIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx).WithName("api-controller")
+	analytics.SendAnonymousInfo(fmt.Sprintf("reconciling API %s ", req.NamespacedName))
 
 	l.Info("Reconciling changed API resource", "changed", req.NamespacedName)
 	defer l.Info("Finished reconciling changed API resource", "changed", req.NamespacedName)
@@ -77,6 +79,7 @@ func (r *APIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		l.Error(err, fmt.Sprintf("Failed to reconcile API, will retry in %d seconds", reconcilerFastRetrySeconds))
 		return ctrl.Result{RequeueAfter: time.Duration(time.Second * time.Duration(reconcilerFastRetrySeconds))}, err
 	}
+
 	// Handle finalisers
 	if apiObj.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is not being deleted, so if it does not have our finalizer,
@@ -111,6 +114,7 @@ func (r *APIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		l.Error(err, fmt.Sprintf("Failed to reconcile API %s, will retry in %d seconds", req.NamespacedName, reconcilerFastRetrySeconds))
 		return ctrl.Result{RequeueAfter: time.Duration(time.Second * time.Duration(reconcilerFastRetrySeconds))}, err
 	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controllers/envoyfleet_controller.go
+++ b/internal/controllers/envoyfleet_controller.go
@@ -65,7 +65,7 @@ type EnvoyFleetReconciler struct {
 func (r *EnvoyFleetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx).WithName("envoy-fleet-controller")
 	l.Info("EnvoyFleet changed", "changed", req.NamespacedName)
-	analytics.SendAnonymousInfo(fmt.Sprintf("reconciling EnvoyFleed %s ", req.NamespacedName))
+	analytics.SendAnonymousInfo(fmt.Sprintf("reconciling EnvoyFleet %s ", req.NamespacedName))
 
 	ef := &gatewayv1alpha1.EnvoyFleet{}
 

--- a/internal/controllers/envoyfleet_controller.go
+++ b/internal/controllers/envoyfleet_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	gatewayv1alpha1 "github.com/kubeshop/kusk-gateway/api/v1alpha1"
+	"github.com/kubeshop/kusk-gateway/pkg/analytics"
 )
 
 const (
@@ -64,6 +65,7 @@ type EnvoyFleetReconciler struct {
 func (r *EnvoyFleetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx).WithName("envoy-fleet-controller")
 	l.Info("EnvoyFleet changed", "changed", req.NamespacedName)
+	analytics.SendAnonymousInfo(fmt.Sprintf("reconciling EnvoyFleed %s ", req.NamespacedName))
 
 	ef := &gatewayv1alpha1.EnvoyFleet{}
 

--- a/internal/controllers/service_controller.go
+++ b/internal/controllers/service_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	gateway "github.com/kubeshop/kusk-gateway/api/v1alpha1"
+	"github.com/kubeshop/kusk-gateway/pkg/analytics"
 )
 
 const (
@@ -59,6 +60,7 @@ func annotation(a string) string {
 //+kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.FromContext(ctx).WithName("service-reconciler")
+	analytics.SendAnonymousInfo(fmt.Sprintf("reconciling Service annotations for kusk  %s", req.NamespacedName))
 
 	l.Info("Reconciling changed Service resource", "changed", req.NamespacedName)
 

--- a/internal/controllers/staticroute_controller.go
+++ b/internal/controllers/staticroute_controller.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	gateway "github.com/kubeshop/kusk-gateway/api/v1alpha1"
+	"github.com/kubeshop/kusk-gateway/pkg/analytics"
 )
 
 const (
@@ -59,6 +60,7 @@ type StaticRouteReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *StaticRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.FromContext(ctx).WithName("static-route-controller")
+	analytics.SendAnonymousInfo(fmt.Sprintf("reconciling Static route  %s", req.NamespacedName))
 
 	l.Info("Reconciling changed StaticRoute resource", "changed", req.NamespacedName)
 	defer l.Info("Finished reconciling changed StaticRoute resource", "changed", req.NamespacedName)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,0 +1,139 @@
+package analytics
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+const (
+	gaUrl = "https://www.google-analytics.com/mp/collect?measurement_id=%s&api_secret=%s"
+)
+
+var (
+	kuskGAApiSecret     = "" // value needs to be passed with LDFLAG set to github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAApiSecret={ACTUAL SECRET}
+	kuskGAMeasurementID = "" // value needs to be passed with LDFLAG set to github.com/kubeshop/kusk-gateway/pkg/analytics.kuskGAMeasurementID=G-V067TPG7HM
+)
+
+func SendAnonymousInfo(event string) {
+	payload := Payload{
+		ClientID: MachineID(),
+		Events: []Event{
+			{
+				Name: event,
+				Params: Params{
+					EventCount: 1,
+					AppName:    "kusk-gateway",
+					DataSource: "gateway",
+				},
+			},
+		},
+	}
+	sendDataToGA(payload)
+}
+
+// SendAnonymouscmdInfo will send CLI event to GA
+func SendAnonymousCMDInfo() {
+	event := "command"
+	command := []string{}
+	if len(os.Args) > 1 {
+		command = os.Args[1:]
+		event = command[0]
+	}
+
+	payload := Payload{
+		ClientID: MachineID(),
+		Events: []Event{
+			{
+				Name: event,
+				Params: Params{
+					EventCount:       1,
+					EventCategory:    "execution",
+					AppName:          "kusk-cli",
+					CustomDimensions: strings.Join(command, " "),
+				},
+			}},
+	}
+	sendDataToGA(payload)
+}
+
+func sendDataToGA(data Payload) error {
+	// if environment variable is set return and collect nothing
+	if _, ok := os.LookupEnv("KUSK_ANALYTICS_DISABLED"); ok {
+		return nil
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonData))
+
+	request, err := http.NewRequest("POST", fmt.Sprintf(gaUrl, kuskGAMeasurementID, kuskGAApiSecret), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 300 {
+		return fmt.Errorf("could not POST, statusCode: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+type Params struct {
+	EventCount       int64  `json:"event_count,omitempty"`
+	EventCategory    string `json:"even_category,omitempty"`
+	AppVersion       string `json:"app_version,omitempty"`
+	AppName          string `json:"app_name,omitempty"`
+	CustomDimensions string `json:"custom_dimensions,omitempty"`
+	DataSource       string `json:"data_source,omitempty"`
+}
+type Event struct {
+	Name   string `json:"name"`
+	Params Params `json:"params,omitempty"`
+}
+type Payload struct {
+	ClientID string  `json:"client_id"`
+	Events   []Event `json:"events"`
+}
+
+// MachineID returns unique user machine ID
+func MachineID() string {
+	id, _ := generate()
+	return id
+}
+
+// Generate returns protected id for the current machine
+func generate() (string, error) {
+	id, err := machineid.ProtectedID("kusk")
+	if err != nil {
+		return fromHostname()
+	}
+	return id, err
+}
+
+// fromHostname generates a machine id hash from hostname
+func fromHostname() (string, error) {
+	name, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	sum := md5.Sum([]byte(name))
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,0 +1,28 @@
+package analytics
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSendAnonymousInfo(t *testing.T) {
+
+	if val, ok := os.LookupEnv("GA_API_SECRET"); ok {
+		KuskGAApiSecret = val
+	} else {
+		t.Skip()
+		return
+	}
+	if val, ok := os.LookupEnv("GA_MEASUREMENT_ID"); ok {
+		KuskGAMeasurementID = val
+	} else {
+		t.Skip()
+		return
+	}
+
+	if err := SendAnonymousInfo("analytics_test"); err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+}


### PR DESCRIPTION
This is first run with telemetry for GW.

There are a couple of things that are really important to point out.
For telemetry to work LDFlags need to passed in compile time Makefile lines 24 and 98/99

In dockerfiles also values for LDflags need to be passed as arguments to the container 
build/agent/Dockerfile Lines 17 and 18 
build/manager/Dockerfile Lines 14 and 15
as ANALYTICS_API_KEY and ANALYTICS_TRACKING_ID.

Also you will notice that telemetry is enabled by default and disable only if users specifically passes KUSK_ANALYTICS_DISABLED=true  

We need to keep track of this for helm charts build as well all other builds which will produce a binary or an image

Signed-off-by: Jasmin Gacic <jasmin.gacic@gmail.com>
