### PR TITLE
Finish Getting Started section with "Connect a Service to the API"

### DIFF
--- a/docs/getting-started/connect-a-service-to-the-api.md
+++ b/docs/getting-started/connect-a-service-to-the-api.md
@@ -1,0 +1,94 @@
+# Connect a Service
+
+Once you have [created an API](deploy-an-api.md) and mocked its responses, you would proceed to implement the services and connect them to the API. This section explains how you would connect your services to Kusk-gateway. 
+
+## 1. Deploy your service
+
+Create a `deployment.yaml` file
+
+```sh 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  selector:
+    matchLabels:
+      app: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+    spec:
+      containers:
+      - name: hello-world
+        image: aabedraba/kusk-hello-world:1.0
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world-svc
+spec:
+  selector:
+    app: hello-world
+  ports:
+  - port: 8080
+    targetPort: 8080
+```
+
+And apply it with 
+
+```sh
+kubectl apply -f deployment.yaml
+```
+
+## 2. Update the API manifest to connect the service to the gateway
+
+Once you have finished implementing and deploying the service, you will need to stop the mocking of the API endpoint and connect the service to the gateway. 
+
+Stop the API mocking by deleting the `mocking` section: 
+
+```diff
+...
+- mocking: 
+-  enabled: true
+...
+```
+
+Add the `upstream` details under the `x-kusk` section to connect the gateway to the service. 
+
+```diff
+...
+x-kusk:
++ upstream:
++  service:
++   name: hello-world-svc
++   namespace: default
++   port: 8080
+...
+```
+
+## 3. Apply the changes
+
+```
+kubectl apply -f api.yaml
+```
+
+## 4. Test the API
+
+The host is the External IP from the [Install Kusk](installation.md) section.
+
+```
+$ curl 127.0.0.1:8080/hello
+Hello from an implemented service!
+```
+
+And now you have succesfully deployed an API! The approach from this "Getting Started" section of the documentation follows a [design-first](https://kubeshop.io/blog/from-design-first-to-automated-deployment-with-openapi) approach where you deployed the API first, mocked the API to and later implemented the services and connected them to the API.
+
+You can also check the [Automatic API Deployment](reference/automatic-api-deployment.md) for a code-first (or service-first) approach. 

--- a/docs/getting-started/deploy-an-api.md
+++ b/docs/getting-started/deploy-an-api.md
@@ -12,6 +12,9 @@ kind: API
 metadata:
   name: hello-world
 spec: 
+  fleet:
+    name: kusk-gateway-envoy-fleet
+    namespace: kusk-system
   spec: |
     openapi: 3.0.0
     info:
@@ -35,7 +38,7 @@ spec:
                 text/plain:
                   schema:
                     type: string
-                  example: Hello world!
+                  example: Hello from a mocked response!
 ```
 
 Kusk-gateway relies on OpenAPI to define your APIs and configure the gateway, all in one place.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -43,7 +43,9 @@ The output should contain the [Envoy Fleet](https://kubeshop.github.io/kusk-gate
 
 !!! note non-important "External IP might not be available for some cluster setups"
 
-    If you are running a local setup with **Minikube**, you can access the API endpoint with `minikube tunnel`
+    If you are running a **local setup**, you can access the API endpoint with 
+    
+    `kubectl port-forward service/kusk-gateway-envoy-fleet 8088:80`
 
     If you are running a **bare metal cluster**, consider installing [MetalLB](https://metallb.universe.tf) which creates External IP for LoadBalancer Service type in Kubernetes.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ You can apply your API definition like any other Kubernetes resource using our c
 
 Other [Custom Resources](reference/customresources/index.md) are used to configure the Envoy Fleet which implements the gateway and specify additional routing configurations.
 
-You can check the supported and planned features at Kusk Gateway [Roadmap](roadmap.md).
+You can check the supported and planned features at Kusk Gateway [Roadmap](contributing/roadmap.md).
 
 Proceed with our [Installation](getting-started/installation.md) instructions for installing to the generic Kubernetes cluster
 

--- a/docs/reference/extension.md
+++ b/docs/reference/extension.md
@@ -25,7 +25,7 @@ x-kusk:
       port: 80
     service: # host and service are mutually exclusive
       namespace: default
-      service: petstore
+      name: petstore
       port: 8000
     rewrite:
       rewrite_regex:
@@ -117,7 +117,7 @@ paths:
           upstream: # routes the POST /pet endpoint to a Kubernetes service
             service:
               namespace: default
-              service: petstore
+              name: petstore
               port: 8000
         ...
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,8 +21,6 @@ nav:
     - Deploy an API: getting-started/deploy-an-api.md
   - 'Guides':
       - 'Using Cert Manager with Kusk Gateway': cert-manager.md
-  - Roadmap: roadmap.md
-  - For Developers: development.md
   - 'Reference':
     - Automatic API deployment: 'reference/automatic-api-deployment.md'
     - 'Custom Resources':

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,8 +17,9 @@ theme:
 nav:
   - Welcome: index.md
   - 'Getting Started': 
-    - Installation: getting-started/installation.md
+    - Install Kusk-gateway: getting-started/installation.md
     - Deploy an API: getting-started/deploy-an-api.md
+    - Connect a Service to the API: getting-started/connect-a-service-to-the-api.md
   - 'Guides':
       - 'Using Cert Manager with Kusk Gateway': cert-manager.md
   - 'Reference':


### PR DESCRIPTION
- Remove roadmap and "for developers" section from main nav
- Add connect a service section
- Add envoy fleet to example manifest
- update links
- Update service.name wrong example in extension reference

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
