### PR TITLE
`Dockerfile`s: Remove cache mount-type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ testbin/
 
 # mkdocs built site
 /site
+
+.tmp/
+/.tmp/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
+SHELL 			= /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$(TELEMETRY_TOKEN)
@@ -55,7 +55,7 @@ deploy-envoyfleet: ## Deploy k8s resources for the single Envoy Fleet
 
 .PHONY: delete-env
 delete-env: ## Destroy the local development Minikube cluster
-	minikube delete --profile kgw	
+	minikube delete --profile kgw
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
@@ -87,15 +87,15 @@ goproxy: ## Starts local goproxy docker instance for the faster builds. Make sur
 .PHONY: docker-images-cache
 docker-images-cache: ## Saves locally frequently used container images and uploads them to Minikube to speed up the development.
 	docker pull gcr.io/distroless/static:nonroot
-	docker pull golang:1.17
+	docker pull docker.io/golang:1.17
 	minikube image load --pull=false --remote=false --overwrite=false --daemon=true gcr.io/distroless/static:nonroot
-	minikube image load --pull=false --remote=false --overwrite=false --daemon=true golang:1.17
+	minikube image load --pull=false --remote=false --overwrite=false --daemon=true docker.io/golang:1.17
 
 ##@ Build
 
 .PHONY: build
 build: generate fmt vet ## Build manager and agent binary.
-	go build -o bin/manager -ldflags='$(LD_FLAGS)' cmd/manager/main.go 
+	go build -o bin/manager -ldflags='$(LD_FLAGS)' cmd/manager/main.go
 	go build -o bin/agent -ldflags='$(LD_FLAGS)' cmd/agent/main.go
 
 .PHONY: run
@@ -105,7 +105,7 @@ run: install-local generate fmt vet ## Run a controller from your host, proxying
 
 .PHONY: docker-build-manager
 docker-build-manager: ## Build docker image with the manager.
-	@eval $$(minikube docker-env --profile kgw); DOCKER_BUILDKIT=1  docker build -t ${MANAGER_IMG} --build-arg GOPROXY=${GOPROXY} -f ./build/manager/Dockerfile .
+	@eval $$(minikube docker-env --profile kgw); DOCKER_BUILDKIT=1 docker build -t ${MANAGER_IMG} --build-arg GOPROXY=${GOPROXY} -f ./build/manager/Dockerfile .
 
 .PHONY: docker-build-agent
 docker-build-agent: ## Build docker image with the agent.
@@ -116,11 +116,11 @@ docker-build: docker-build-manager docker-build-agent ## Build docker images for
 
 .PHONY: docker-build-manager-debug
 docker-build-manager-debug: ## Build docker image with the manager and debugger.
-	@eval $$(SHELL=/bin/bash minikube docker-env --profile kgw) ;DOCKER_BUILDKIT=1 docker build -t "${MANAGER_IMG}-debug" --build-arg GOPROXY=${GOPROXY}  -f ./build/manager/Dockerfile-debug .
+	@eval $$(minikube docker-env --profile kgw); DOCKER_BUILDKIT=1 docker build -t "${MANAGER_IMG}-debug" --build-arg GOPROXY=${GOPROXY} -f ./build/manager/Dockerfile-debug .
 
 .PHONY: docker-build-agent-debug
 docker-build-agent-debug:  ## Build docker image with the agent and debugger.
-	@eval $$(SHELL=/bin/bash minikube docker-env --profile kgw) ;DOCKER_BUILDKIT=1 docker build -t "${AGENT_IMG}-debug" --build-arg GOPROXY=${GOPROXY}  -f ./build/agent/Dockerfile-debug .
+	@eval $$(minikube docker-env --profile kgw); DOCKER_BUILDKIT=1 docker build -t "${AGENT_IMG}-debug" --build-arg GOPROXY=${GOPROXY} -f ./build/agent/Dockerfile-debug .
 
 ##@ Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ goproxy: ## Starts local goproxy docker instance for the faster builds. Make sur
 docker-images-cache: ## Saves locally frequently used container images and uploads them to Minikube to speed up the development.
 	docker pull gcr.io/distroless/static:nonroot
 	docker pull docker.io/golang:1.17
-	minikube image load --pull=false --remote=false --overwrite=false --daemon=true gcr.io/distroless/static:nonroot
-	minikube image load --pull=false --remote=false --overwrite=false --daemon=true docker.io/golang:1.17
+	minikube image load --pull=false --remote=false --overwrite=false --daemon=true gcr.io/distroless/static:nonroot --profile kgw
+	minikube image load --pull=false --remote=false --overwrite=false --daemon=true docker.io/golang:1.17 --profile kgw
 
 ##@ Build
 

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM docker.io/golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -14,11 +14,10 @@ RUN go mod download
 # Copy the go source
 COPY . .
 
-
-ARG TELEMETRY_TOKEN 
+ARG TELEMETRY_TOKEN
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN" -o agent cmd/agent/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN" -o agent cmd/agent/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build/agent/Dockerfile-debug
+++ b/build/agent/Dockerfile-debug
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM docker.io/golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 go get github.com/go-delve/delve/cmd/dlv@v1.8.0
 COPY . .
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -v -o agent cmd/agent/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -v -o agent cmd/agent/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build/manager/Dockerfile
+++ b/build/manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM docker.io/golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -11,13 +11,13 @@ ARG GOPROXY
 ENV GOPROXY=$GOPROXY
 RUN go mod download
 
-ARG TELEMETRY_TOKEN 
+ARG TELEMETRY_TOKEN
 
 # Copy the go source
 COPY . .
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN" -o manager cmd/manager/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN" -o manager cmd/manager/main.go
 
 # Directory for the files created and used by the manager, to be copied for static rootless images since we don't have shell to create it there
 RUN mkdir -m=00755 /opt/manager

--- a/build/manager/Dockerfile-debug
+++ b/build/manager/Dockerfile-debug
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM docker.io/golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 go get github.com/go-delve/delve/cmd/dlv@v1.8.0
 COPY . .
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -v -o manager cmd/manager/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -v -o manager cmd/manager/main.go
 
 # Directory for the files created and used by the manager, to be copied for static rootless images since we don't have shell to create it there
 RUN mkdir -m=00755 /opt/manager

--- a/development/cluster/create-env.sh
+++ b/development/cluster/create-env.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -e
 
 echo "========> creating cluster..."


### PR DESCRIPTION
Closes #379.

`Dockerfile`s:
--------------

1. Use `docker.io/golang:1.17`, i.e., fully qualified path to image.
2. Remove unneeded caching:

```Dockerfile
...
RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg ...
...
```

Etc. from `Dockerfile`s:

* `build/agent/Dockerfile`.
* `build/agent/Dockerfile-debug`.
* `build/manager/Dockerfile`.
* `build/agent/Dockerfile-debug`.

`Makefile`
----------

1. Use `docker.io/golang:1.17`, i.e., fully qualified path to image.
2. Tidyup `Makefile`.
3. Add `--profile kgw` to `docker-images-cache` target.

Misc
----

* Ignore `.tmp/` folder.

This PR...

---

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
