### PR TITLE
add ratelimiting

### DIFF
--- a/development/testing/manifests/api.yaml
+++ b/development/testing/manifests/api.yaml
@@ -14,6 +14,11 @@ spec:
       version: 1.0.0
     x-kusk:
       hosts: [ "example.org", "example.com"]
+      rate_limit:
+        requests_per_unit: 2
+        unit: minute
+        per_connection: false
+        response_code: 429
       cors:
         origins:
           - 'http://example.org'

--- a/internal/controllers/config_manager.go
+++ b/internal/controllers/config_manager.go
@@ -155,7 +155,10 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 		}
 	}
 
-	httpConnectionManagerBuilder := config.NewHCMBuilder()
+	httpConnectionManagerBuilder, err := config.NewHCMBuilder()
+	if err != nil {
+		return fmt.Errorf("failed to get HTTP connection manager: %w", err)
+	}
 	if fleet.Spec.AccessLog != nil {
 		var accessLogBuilder *config.AccessLogBuilder
 		var err error

--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -29,8 +29,11 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	ratelimit "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
 	envoytypematcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/getkin/kin-openapi/openapi3"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -242,6 +245,7 @@ func UpdateConfigFromAPIOpts(envoyConfiguration *config.EnvoyConfiguration, mock
 				if finalOpts.Upstream != nil && finalOpts.Upstream.Rewrite.Pattern != "" {
 					rewriteOpts = &finalOpts.Upstream.Rewrite
 				}
+
 				routeRoute, err := generateRoute(
 					clusterName,
 					corsPolicy,
@@ -257,6 +261,21 @@ func UpdateConfigFromAPIOpts(envoyConfiguration *config.EnvoyConfiguration, mock
 
 			// For the list of vhosts that we create exactly THIS configuration for, update the routes
 			for _, vh := range opts.Hosts {
+				filterConf := map[string]*anypb.Any{}
+
+				if finalOpts.RateLimit != nil {
+					rl := mapRateLimitConf(finalOpts.RateLimit, generateRateLimitStatPrefix(string(vh), path, method, operation.OperationID))
+					anyRateLimit, err := anypb.New(rl)
+					if err != nil {
+						return fmt.Errorf("failure marshalling ratelimiting configuration: %w ", err)
+					}
+					filterConf = map[string]*anypb.Any{
+						"envoy.filters.http.local_ratelimit": anyRateLimit,
+					}
+
+				}
+				rt.TypedPerFilterConfig = filterConf
+
 				if err := envoyConfiguration.AddRouteToVHost(string(vh), rt); err != nil {
 					return fmt.Errorf("failure adding the route to vhost %s: %w ", string(vh), err)
 				}
@@ -328,13 +347,8 @@ func UpdateConfigFromOpts(envoyConfiguration *config.EnvoyConfiguration, opts *o
 
 			// routeMatcher defines how we match a route by the provided path and the headers
 			rt := &route.Route{
-				Name: generateRouteName(routePath, strMethod),
-				Match: generateRouteMatch(
-					routePath,
-					string(method),
-					nil,
-					corsPolicy,
-				),
+				Name:  generateRouteName(routePath, strMethod),
+				Match: generateRouteMatch(routePath, string(method), nil, corsPolicy),
 			}
 
 			if methodOpts.Redirect != nil {
@@ -371,6 +385,7 @@ func UpdateConfigFromOpts(envoyConfiguration *config.EnvoyConfiguration, opts *o
 			}
 			// For the list of vhosts that we create exactly THIS configuration for, update the routes
 			for _, vh := range opts.Hosts {
+
 				if err := envoyConfiguration.AddRouteToVHost(string(vh), rt); err != nil {
 					return fmt.Errorf("failure adding the route to vhost %s: %w ", string(vh), err)
 				}
@@ -446,6 +461,10 @@ func generateMockID(path string, method string, operationID string) string {
 	return fmt.Sprintf("%s-%s-%s", path, method, operationID)
 }
 
+func generateRateLimitStatPrefix(host, path, method, operationID string) string {
+	return fmt.Sprintf("%s-%s-%s-%s", host, path, method, operationID)
+}
+
 // Can be moved to operationID, but generally we just need unique string
 func generateRouteName(path string, method string) string {
 	return fmt.Sprintf("%s-%s", path, strings.ToUpper(method))
@@ -519,4 +538,49 @@ func generateRoute(
 	}
 
 	return routeRoute, nil
+}
+
+func mapRateLimitConf(rlOpt *options.RateLimitOptions, statPrefix string) *ratelimit.LocalRateLimit {
+	var seconds int64
+	switch rlOpt.Unit {
+	case "second":
+		seconds = 1
+	case "minute":
+		seconds = 60
+	case "hour":
+		seconds = 60 * 60
+	}
+	rl := &ratelimit.LocalRateLimit{
+		StatPrefix: statPrefix,
+		Status: &envoy_type_v3.HttpStatus{
+			Code: envoy_type_v3.StatusCode(rlOpt.ResponseCode),
+		},
+		TokenBucket: &envoy_type_v3.TokenBucket{
+			MaxTokens: rlOpt.RequestsPerUnit,
+			TokensPerFill: &wrapperspb.UInt32Value{
+				Value: rlOpt.RequestsPerUnit,
+			},
+			FillInterval: &durationpb.Duration{
+				Seconds: seconds,
+			},
+		},
+		FilterEnabled: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enabled",
+		},
+		FilterEnforced: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enforced",
+		},
+		Stage:                                 0,
+		LocalRateLimitPerDownstreamConnection: rlOpt.PerConnection,
+	}
+
+	return rl
 }

--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -550,10 +550,17 @@ func mapRateLimitConf(rlOpt *options.RateLimitOptions, statPrefix string) *ratel
 	case "hour":
 		seconds = 60 * 60
 	}
+
+	responseCode := rlOpt.ResponseCode
+	if responseCode == 0 {
+		// HTTP Status too many requests
+		responseCode = 429
+	}
+
 	rl := &ratelimit.LocalRateLimit{
 		StatPrefix: statPrefix,
 		Status: &envoy_type_v3.HttpStatus{
-			Code: envoy_type_v3.StatusCode(rlOpt.ResponseCode),
+			Code: envoy_type_v3.StatusCode(responseCode),
 		},
 		TokenBucket: &envoy_type_v3.TokenBucket{
 			MaxTokens: rlOpt.RequestsPerUnit,

--- a/internal/controllers/parser_test.go
+++ b/internal/controllers/parser_test.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"testing"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ratelimit "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/kubeshop/kusk-gateway/pkg/options"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestMapRateLimitConf(t *testing.T) {
+	rlOpt := &options.RateLimitOptions{
+		RequestsPerUnit: 2,
+		Unit:            "minute",
+		PerConnection:   false,
+		ResponseCode:    403,
+	}
+	out := mapRateLimitConf(rlOpt, "stat_prefix")
+
+	want := &ratelimit.LocalRateLimit{
+		StatPrefix: "stat_prefix",
+		Status: &envoy_type_v3.HttpStatus{
+			Code: envoy_type_v3.StatusCode(rlOpt.ResponseCode),
+		},
+		TokenBucket: &envoy_type_v3.TokenBucket{
+			MaxTokens: 2,
+			TokensPerFill: &wrapperspb.UInt32Value{
+				Value: 2,
+			},
+			FillInterval: &durationpb.Duration{
+				Seconds: 60,
+			},
+		},
+		FilterEnabled: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enabled",
+		},
+		FilterEnforced: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enforced",
+		},
+		Stage:                                 0,
+		LocalRateLimitPerDownstreamConnection: rlOpt.PerConnection,
+	}
+
+	assert.Equal(t, want, out)
+}

--- a/internal/controllers/parser_test.go
+++ b/internal/controllers/parser_test.go
@@ -55,3 +55,45 @@ func TestMapRateLimitConf(t *testing.T) {
 
 	assert.Equal(t, want, out)
 }
+
+func TestMapRateLimitConfDefault(t *testing.T) {
+	rlOpt := &options.RateLimitOptions{
+		RequestsPerUnit: 2,
+		Unit:            "minute",
+	}
+	out := mapRateLimitConf(rlOpt, "stat_prefix")
+
+	want := &ratelimit.LocalRateLimit{
+		StatPrefix: "stat_prefix",
+		Status: &envoy_type_v3.HttpStatus{
+			Code: envoy_type_v3.StatusCode(429),
+		},
+		TokenBucket: &envoy_type_v3.TokenBucket{
+			MaxTokens: 2,
+			TokensPerFill: &wrapperspb.UInt32Value{
+				Value: 2,
+			},
+			FillInterval: &durationpb.Duration{
+				Seconds: 60,
+			},
+		},
+		FilterEnabled: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enabled",
+		},
+		FilterEnforced: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enforced",
+		},
+		Stage:                                 0,
+		LocalRateLimitPerDownstreamConnection: false,
+	}
+
+	assert.Equal(t, want, out)
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -72,6 +72,7 @@ type SubOptions struct {
 	Websocket  *bool              `json:"websocket,omitempty" yaml:"websocket,omitempty"`
 	Validation *ValidationOptions `json:"validation,omitempty" yaml:"validation,omitempty"`
 	Mocking    *MockingOptions    `json:"mocking,omitempty" yaml:"mocking,omitempty"`
+	RateLimit  *RateLimitOptions  `json:"rate_limit,omitempty" yaml:"rate_limit,omitempty"`
 }
 
 func (o SubOptions) Validate() error {
@@ -156,6 +157,10 @@ func (o *SubOptions) MergeInSubOptions(in *SubOptions) {
 	// Mocking
 	if o.Mocking == nil && in.Mocking != nil {
 		o.Mocking = in.Mocking
+	}
+	// RateLimit
+	if o.RateLimit == nil && in.RateLimit != nil {
+		o.RateLimit = in.RateLimit
 	}
 
 	return

--- a/pkg/options/ratelimit.go
+++ b/pkg/options/ratelimit.go
@@ -23,13 +23,20 @@ SOFTWARE.
 */
 package options
 
+import "fmt"
+
 type RateLimitOptions struct {
-	RPS   uint32 `json:"rps,omitempty" yaml:"rps,omitempty"`
-	Burst uint32 `json:"burst,omitempty" yaml:"burst,omitempty"`
-	Group string `json:"group,omitempty" yaml:"group,omitempty"`
+	RequestsPerUnit uint32 `json:"requests_per_unit,omitempty" yaml:"requests_per_unit,omitempty"`
+	Unit            string `json:"unit,omitempty" yaml:"unit,omitempty"`
+	PerConnection   bool   `json:"per_connection,omitempty" yaml:"per_connection,omitempty"`
+	ResponseCode    uint32 `yaml:"response_code,omitempty" json:"response_code,omitempty"`
 }
 
 func (o RateLimitOptions) Validate() error {
-	// TODO: write validations
+	switch o.Unit {
+	case "minute", "second", "hour":
+	default:
+		return fmt.Errorf("unsupported unit '%s', must be second, minute or hour", o.Unit)
+	}
 	return nil
 }


### PR DESCRIPTION
Adds x-kusk extension for rate-limiting, similar to @crjones design:

```
      rate_limit:
        requests_per_unit: 2
        unit: minute
        per_connection: false
        response_code: 429
```

Ref https://github.com/kubeshop/kusk-gateway/issues/24