### PR TITLE
added namespaces to kusk-gateway-envoyfleet-manager-role

### DIFF
--- a/config/rbac/envoyfleet_manager_role.yaml
+++ b/config/rbac/envoyfleet_manager_role.yaml
@@ -23,6 +23,7 @@ rules:
     resources:
       - services
       - configmaps
+      - namespaces
     verbs:
       - create
       - delete


### PR DESCRIPTION
This is an important update to RBAC without which kgw API server won't be able to fetch Namespaces

Closes #442 
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>
