### PR TITLE
e2e tests/smoketests: Add rate limiting smoketests - Closes kubeshop/kusk-gateway#471

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,16 +243,16 @@ rm -rf $${TMP_DIR} ;\
 }
 endef
 
-start-smoke-tests: 
+start-smoke-tests:
 	@docker rm smoke-registry -f
 	@docker run -d -p 50000:5000 --name smoke-registry registry:2
 	@docker build -t localhost:50000/kusk-gateway:latest -f ./build/manager/Dockerfile .
 	@docker push localhost:50000/kusk-gateway:latest
-	$(MAKE) deploy-local-registry 
-	
+	$(MAKE) deploy-local-registry
+
 deploy-local-registry: $(ENVTEST) $(KUSTOMIZE)
 	echo $(shell pwd)
-	bin/kustomize build smoketests/common  | kubectl apply -f -
+	bin/kustomize build smoketests/common | kubectl apply -f -
 	$(MAKE) cycle
 	$(MAKE) deploy-envoyfleet
 
@@ -261,4 +261,4 @@ $(smoketests): start-smoke-tests
 	$(MAKE) -C smoketests $@
 	@rm -rf smoketests/bin
 
-check-all: check-basic check-mocking check-basic_auth
+check-all: check-basic check-mocking check-basic_auth check-rate_limit

--- a/docs/guides/rate-limit.md
+++ b/docs/guides/rate-limit.md
@@ -16,7 +16,7 @@ x-kusk:
 ..
 ```
 
-The example above allows only up to two requests per minute to be sent to the whole API. 
+The example above allows only up to two requests per minute to be sent to the whole API.
 
 You can also specify different rate-limiting settings for a specific operation or path. The following example shows rate limiting configuration for a specific operation:
 

--- a/docs/reference/extension.md
+++ b/docs/reference/extension.md
@@ -227,12 +227,12 @@ Note: Currently `mocking` is incompatible with the `validation` option - the con
 
 The rate_limit object contains the following properties to configure request rate limiting:
 
-| Name                 | Description                    |
-|:---------------------|--------------------------------|
-| `rate_limit.requests_per_unit`    | How many requests API can handle per unit of time. |
-| `rate_limit.unit`                 | Unit of time, can be one of the following: second, minute, hour . |
-| `rate_limit.per_connection`       | Boolean flag, that specifies whether the rate limiting, should be applied per connection or in total. Default: false. |
-| `rate_limit.response_code`        | HTTP response code, which is returned when rate limiting. Default: 429, Too Many Requests. |
+| Name                              | Description                                                                                                              |
+|:----------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `rate_limit.requests_per_unit`    | How many requests API can handle per unit of time.                                                                       |
+| `rate_limit.unit`                 | Unit of time, can be one of the following: second, minute, hour .                                                        |
+| `rate_limit.per_connection`       | Boolean flag, that specifies whether the rate limiting, should be applied per connection or in total. Default: false.    |
+| `rate_limit.response_code`        | HTTP response code, which is returned when rate limiting. Default: 429, Too Many Requests.                               |
 
 Note: Currently, rate limiting is applied per Envoy pod - if you have more than a single Envoy pod the total request capacity will be bigger than specified in the rate_limit object. You can check how many Envoy pods you run in the `spec.size` attribute of [EnvoyFleet object](../customresources/envoyfleet.md).
 

--- a/smoketests/Makefile
+++ b/smoketests/Makefile
@@ -1,6 +1,5 @@
 include Makefile.variables
 
-
 $(smoketests):
 	go mod tidy
 	go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/$(subst check-,,$@)
@@ -9,9 +8,8 @@ check-basic_auth:
 	kubectl apply -f ../examples/ext-authz
 	go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/$(subst check-,,$@)
 	# kubectl delete -f ../examples/ext-authz
-	
-sandbox: 
+
+sandbox:
 	@docker build samples/hello-world/hello-world-container/ -t localhost:50000/hello-world:smoke
 	@docker push localhost:50000/hello-world:smoke
 	kubectl apply -f samples/hello-world/deployment.yaml
-	

--- a/smoketests/Makefile.variables
+++ b/smoketests/Makefile.variables
@@ -1,4 +1,5 @@
 smoketests := \
     check-mocking \
     check-basic \
-    check-basic_auth
+    check-basic_auth \
+    check-rate_limit

--- a/smoketests/basic_auth/basicauth_test.go
+++ b/smoketests/basic_auth/basicauth_test.go
@@ -63,7 +63,7 @@ func (m *BasicAuthCheckSuite) TestAuthorized() {
 	m.NoError(err)
 
 	defer resp.Body.Close()
-	m.Equal(200, resp.StatusCode)
+	m.Equal(http.StatusOK, resp.StatusCode)
 }
 
 func (m *BasicAuthCheckSuite) TestUnauthorized() {
@@ -80,7 +80,7 @@ func (m *BasicAuthCheckSuite) TestUnauthorized() {
 	m.NoError(err)
 
 	defer resp.Body.Close()
-	m.Equal(401, resp.StatusCode)
+	m.Equal(http.StatusUnauthorized, resp.StatusCode)
 }
 
 func (m *BasicAuthCheckSuite) TestForbidden() {
@@ -93,7 +93,7 @@ func (m *BasicAuthCheckSuite) TestForbidden() {
 
 	defer resp.Body.Close()
 
-	m.Equal(403, resp.StatusCode)
+	m.Equal(http.StatusForbidden, resp.StatusCode)
 }
 
 func (m *BasicAuthCheckSuite) TearDownSuite() {

--- a/smoketests/rate_limit/rate_limit_test.go
+++ b/smoketests/rate_limit/rate_limit_test.go
@@ -1,0 +1,123 @@
+package rate_limit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	kuskv1 "github.com/kubeshop/kusk-gateway/api/v1alpha1"
+	"github.com/kubeshop/kusk-gateway/smoketests/common"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	defaultNamespace = "default"
+	defaultName      = "default"
+	testName         = "auth-test"
+)
+
+type RateLimitTestSuite struct {
+	common.KuskTestSuite
+	api *kuskv1.API
+}
+
+func (t *RateLimitTestSuite) SetupTest() {
+	rawApi := common.ReadFile("../samples/hello-world/rate_limit.yaml")
+	api := &kuskv1.API{}
+	t.NoError(yaml.Unmarshal([]byte(rawApi), api))
+
+	api.ObjectMeta.Name = testName
+	api.ObjectMeta.Namespace = defaultNamespace
+	api.Spec.Fleet.Name = defaultName
+	api.Spec.Fleet.Namespace = defaultNamespace
+
+	if err := t.Cli.Create(context.Background(), api, &client.CreateOptions{}); err != nil {
+		if strings.Contains(err.Error(), `apis.gateway.kusk.io "test-rate-limit" already exists`) {
+			return
+		}
+
+		t.Fail(err.Error(), nil)
+	}
+
+	t.api = api // store `api` for deletion later
+
+	time.Sleep(1 * time.Second) // weird way to wait it out probably needs to be done dynamically
+}
+
+func (t *RateLimitTestSuite) TestRateLimitReached() {
+	// We are expecting 429 Too Many Requests with a body of `local_rate_limited` once we do 3 requests.
+
+	envoyFleetSvc := getEnvoyFleetSvc(t)
+
+	const (
+		Rate_Limit = 2
+	)
+	var (
+		url = fmt.Sprintf("http://%s/rate_limit", envoyFleetSvc.Status.LoadBalancer.Ingress[0].IP)
+	)
+
+	// Do 2 requests then the next one will fail
+	for x := 0; x < Rate_Limit; x++ {
+		func() {
+			req, err := http.NewRequest("GET", url, nil)
+			t.NoError(err)
+
+			res, err := http.DefaultClient.Do(req)
+			t.NoError(err)
+
+			defer res.Body.Close()
+
+			responseBody, err := io.ReadAll(res.Body)
+			t.NoError(err)
+
+			body := map[string]string{}
+			t.NoError(json.Unmarshal(responseBody, &body))
+
+			t.Equal(http.StatusOK, res.StatusCode)
+			t.Equal(`rate-limited mocked response.`, body["message"])
+		}()
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	t.NoError(err)
+
+	res, err := http.DefaultClient.Do(req)
+	t.NoError(err)
+
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	t.NoError(err)
+
+	t.Equal(http.StatusTooManyRequests, res.StatusCode)
+	t.Equal("local_rate_limited", string(responseBody))
+}
+
+func (t *RateLimitTestSuite) TearDownSuite() {
+	t.NoError(t.Cli.Delete(context.Background(), t.api, &client.DeleteOptions{}))
+}
+
+func TestRateLimitTestSuite(t *testing.T) {
+	testSuite := RateLimitTestSuite{}
+	suite.Run(t, &testSuite)
+}
+
+func getEnvoyFleetSvc(t *RateLimitTestSuite) *corev1.Service {
+	t.T().Helper()
+
+	envoyFleetSvc := &corev1.Service{}
+	t.NoError(
+		t.Cli.Get(context.Background(), client.ObjectKey{Name: defaultName, Namespace: defaultNamespace}, envoyFleetSvc),
+	)
+
+	return envoyFleetSvc
+}

--- a/smoketests/samples/hello-world/rate_limit.yaml
+++ b/smoketests/samples/hello-world/rate_limit.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.kusk.io/v1alpha1
+kind: API
+metadata:
+  name: test-rate-limit
+spec:
+  fleet:
+    name: default
+    namespace: default
+  # service name and port should be specified inside x-kusk annotation
+  spec: |
+    components: {}
+    info:
+      title: simple-api
+      version: 0.1.0
+    openapi: 3.0.0
+    x-kusk:
+      cors:
+        methods:
+        - GET
+        - POST
+        origins:
+        - '*'
+      mocking:
+        enabled: true
+    paths:
+      /rate_limit:
+        get:
+          x-kusk:
+            rate_limit:
+              requests_per_unit: 2
+              unit: minute
+          responses:
+            "200":
+              content:
+                application/json:
+                  example:
+                    message: rate-limited mocked response.
+                  schema:
+                    properties:
+                      message:
+                        type: string
+                    type: object
+              description: A simple hello world!


### PR DESCRIPTION
Add Rate limiting smoketests/e2e tests.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

This PR...

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
