### PR TITLE
`smoketests/basic_auth`: Wait for `ext-authz-http-service` deployment to be ready and sleep an additional 6 seconds

### DIFF
--- a/smoketests/Makefile
+++ b/smoketests/Makefile
@@ -6,10 +6,13 @@ $(smoketests):
 
 check-basic_auth:
 	kubectl apply -f ../examples/ext-authz
+	kubectl wait deployment --namespace=default ext-authz-http-service --for condition=Available=True --timeout=90s
+	@echo "sleeping for 6s ..."
+	@sleep 6s
 	go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/$(subst check-,,$@)
 	kubectl delete -f ../examples/ext-authz
-	
-sandbox: 
+
+sandbox:
 	@docker build samples/hello-world/hello-world-container/ -t localhost:50000/hello-world:smoke
 	@docker push localhost:50000/hello-world:smoke
 	kubectl apply -f samples/hello-world/deployment.yaml


### PR DESCRIPTION
Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
