### PR TITLE
Maintain hostname when requesting from upstream host

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -56,8 +56,3 @@ vars:
       kind: Service
       name: kusk-gateway-webhooks-service
       version: v1
-
-images:
-  - name: kusk-gateway
-    newName: kubeshop/kusk-gateway
-    newTag: v1.1.0-rc1

--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -356,6 +356,13 @@ func UpdateConfigFromAPIOpts(
 				if err != nil {
 					return err
 				}
+
+				// https://github.com/kubeshop/kusk-gateway/issues/404
+				// to help with issues around direct IP access e.g. CloudFlare
+				routeRoute.Route.HostRewriteSpecifier = &route.RouteAction_HostRewriteLiteral{
+					HostRewriteLiteral: upstreamHostname,
+				}
+
 				rt.Action = routeRoute
 
 				routesToAddToVirtualHost = append(routesToAddToVirtualHost, rt)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -72,6 +72,10 @@ func (o Options) Validate() error {
 		return o.Upstream.Validate()
 	}
 
+	if o.Redirect != nil {
+		return o.Redirect.Validate()
+	}
+
 	// if we get here, it means there aren't global options contains either mocking or an upstream service that covers all endpoints
 	// therefore we need to iterate over all operations and check if they have either mocking or an upstream service
 	for pathAndMethod, op := range o.OperationFinalSubOptions {
@@ -81,6 +85,10 @@ func (o Options) Validate() error {
 
 		if op.Upstream != nil {
 			return o.Upstream.Validate()
+		}
+
+		if op.Redirect != nil {
+			return o.Redirect.Validate()
 		}
 
 		// if we reach here then this path that doesn't have either mocking or an upstream service and is not covered by a
@@ -207,6 +215,4 @@ func (o *SubOptions) MergeInSubOptions(in *SubOptions) {
 	if o.Auth == nil && in.Auth != nil {
 		o.Auth = in.Auth
 	}
-
-	return
 }


### PR DESCRIPTION
This PR fixes #404 

Add host header literal rewrite to overcome issues with accessing IP directly such as with cloudflare. This ensures there is a host header value present once Envoy has performed the DNS lookup and forwards the request onto the returned IP when simply proxying the request upstream

## Changes

- Add `HostRewriteSpecifier` to Route in parser when handling a request proxy to upstream

## Fixes

- Error 1003 Direct IP access not allowed when accessing upstream services fronted by CloudFlare

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
