### PR TITLE
Add -ldflags '-s -w' to go build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ SHELL 			= /usr/bin/env bash -o pipefail
 LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/analytics.Telemetry_Token=$(TELEMETRY_TOKEN)
 LD_FLAGS += -X github.com/kubeshop/kusk-gateway/pkg/build.Version=$(VERSION)
 
+# strip DWARF, symbol table and debug info. Expect ~25% binary size decrease
+# https://github.com/kubeshop/kusk-gateway/issues/431
+LD_FLAGS += -s -w
+
 export DOCKER_BUILDKIT 	?=	1
 
 .PHONY: all

--- a/build/manager/Dockerfile
+++ b/build/manager/Dockerfile
@@ -18,7 +18,7 @@ ARG VERSION
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN -X github.com/kubeshop/kusk-gateway/pkg/build.Version=$VERSION" -o manager cmd/manager/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -v -ldflags "-X github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN -X github.com/kubeshop/kusk-gateway/pkg/build.Version=$VERSION -s -w" -o manager cmd/manager/main.go
 
 # Directory for the files created and used by the manager, to be copied for static rootless images since we don't have shell to create it there
 RUN mkdir -m=00755 /opt/manager


### PR DESCRIPTION
Add -ldflags '-s -w' to go build commands to strip DWARF, symbol table and debug info from manager binary

This PR closes #431 

```
Before: 
Before: 
-rwxr-xr-x   1 kylehodgetts  staff    57M Jul  1 11:54 manager
kubeshop/kusk-gateway                     v1.1.0-rc1   844581827771   7 days ago       64.1MB

After:
-rwxr-xr-x   1 kylehodgetts  staff    46M Jul  1 11:56 manager
kusk-gateway                              dev          e9269855e07f   12 seconds ago   46.2MB
```

Nice 👍 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
