### PR TITLE
`internal/controllers/parser.go`: Fix auth bug, missing `fallthrough`

### DIFF
--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -332,6 +332,7 @@ func UpdateConfigFromAPIOpts(
 					return err
 				}
 				httpConnectionManagerBuilder.AppendFilterHTTPExternalAuthorizationFilterToStart(httpExternalAuthorizationFilter)
+				fallthrough
 			// Default - proxy to the upstream
 			default:
 				upstreamHostname, upstreamPort := getUpstreamHost(finalOpts.Upstream)


### PR DESCRIPTION
Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

```sh
$ kubectl apply -f examples/ext-authz/ext-authz-http-service-api.yaml
$ kubectl apply -f examples/ext-authz/ext-authz-http-service.yaml
$ kubectl apply -f examples/httpbin/manifest.yaml
$ curl -v 192.168.49.2/
*   Trying 192.168.49.2:80...
* Connected to 192.168.49.2 (192.168.49.2) port 80 (#0)
> GET / HTTP/1.1
> Host: 192.168.49.2
> User-Agent: curl/7.82.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 403 Forbidden
< date: Wed, 06 Jul 2022 12:47:45 GMT
< server: envoy
< content-length: 0
< 
* Connection #0 to host 192.168.49.2 left intact
$ curl --user kubeshop:kubeshopx 192.168.49.2/
Unauthorized - hint: credentials are kubeshop:kubeshop%
$ curl --user kubeshop:kubeshop 192.168.49.2/
```

----

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
