### PR TITLE
Rename annotation to `gateway.kusk.io`

### DIFF
--- a/docs/guides/autodeploy.md
+++ b/docs/guides/autodeploy.md
@@ -8,10 +8,10 @@ The following annotations are available:
 
 | Name                                    | Description                                                                   | Optional |
 |:----------------------------------------|:------------------------------------------------------------------------------|:--------:|
-| `kusk-gateway/openapi-url`              | The absolute URL to the OpenAPI definition to deploy.                          |          |
-| `kusk-gateway/envoy-fleet`              | Which EnvoyFleet to use.                                                       |    X     |
-| `kusk-gateway/path-prefix:`             | The path where your API will be hosted.                                         |    X     |
-| `kusk-gateway/path-prefix-substitution` | What to substitute the prefix with when forwarding the request to the service. |    X     |
+| `gateway.kusk.io/openapi-url`              | The absolute URL to the OpenAPI definition to deploy.                          |          |
+| `gateway.kusk.io/envoy-fleet`              | Which EnvoyFleet to use.                                                       |    X     |
+| `gateway.kusk.io/path-prefix:`             | The path where your API will be hosted.                                         |    X     |
+| `gateway.kusk.io/path-prefix-substitution` | What to substitute the prefix with when forwarding the request to the service. |    X     |
 
 For example, assuming that you have set up a deployment that is running your REST API, you could deploy 
 the following Kubernetes Service: 
@@ -22,7 +22,7 @@ kind: Service
 metadata:
   name: my-api
   annotations:
-    kusk-gateway/openapi-url: https://some-resolvablehost-name/path-to-openapi.yaml
+    gateway.kusk.io/openapi-url: https://some-resolvablehost-name/path-to-openapi.yaml
 spec:
   type: ClusterIP
   selector:
@@ -46,10 +46,10 @@ kind: Service
 metadata:
   name: my-api
   annotations:
-    kusk-gateway/openapi-url: https://gist.githubusercontent.com/jasmingacic/082849b29d0e06e5f018a66f4cd49ec3/raw/e91c94cc82e7591031399e0d8c563d28a62de460/openapi.yaml
-    kusk-gateway/path-prefix: /my-api
-    kusk-gateway/path-prefix-substitution: ""
-    kusk-gateway/envoy-fleet: my-private-fleet
+    gateway.kusk.io/openapi-url: https://gist.githubusercontent.com/jasmingacic/082849b29d0e06e5f018a66f4cd49ec3/raw/e91c94cc82e7591031399e0d8c563d28a62de460/openapi.yaml
+    gateway.kusk.io/path-prefix: /my-api
+    gateway.kusk.io/path-prefix-substitution: ""
+    gateway.kusk.io/envoy-fleet: my-private-fleet
 spec:
   type: ClusterIP
   selector:

--- a/internal/controllers/service_controller.go
+++ b/internal/controllers/service_controller.go
@@ -59,7 +59,7 @@ type ServiceReconciler struct {
 }
 
 func annotation(a string) string {
-	return fmt.Sprintf("kusk-gateway/%s", a)
+	return fmt.Sprintf("gateway.kusk.io/%s", a)
 }
 
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
@@ -87,7 +87,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	openAPIUrlAnnotation := annotation(annotationOpenapiUrl)
 	openApiUrl, ok := svc.Annotations[openAPIUrlAnnotation]
 	if !ok {
-		// if the service doesn't have the kusk-gateway/openapi-url annotation then we dont do anything
+		// if the service doesn't have the gateway.kusk.io/openapi-url annotation then we dont do anything
 		// as this is the minimum requirement for the service reconciler to have an effect
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Use public Kubernetes annotations by having keys, e.g., (`gateway.kusk.io`), that contain periods.

Closes kubeshop/kusk#49.

See <https://github.com/kubeshop/kusk/issues/49>.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

**Note:** kubeshop/helm-charts#200 depends on this.

---

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
