### PR TITLE
Misc improvements

### DIFF
--- a/internal/controllers/config_manager.go
+++ b/internal/controllers/config_manager.go
@@ -192,7 +192,7 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 		}
 		httpConnectionManagerBuilder.AddAccessLog(accessLogBuilder.GetAccessLog())
 	}
-	if err := httpConnectionManagerBuilder.Validate(); err != nil {
+	if err := httpConnectionManagerBuilder.ValidateAll(); err != nil {
 		l.Error(err, "Failed validation for HttpConnectionManager", "fleet", fleetIDstr)
 		return fmt.Errorf("failed validation for HttpConnectionManager")
 	}
@@ -233,7 +233,7 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 		return err
 	}
 
-	if err := listenerBuilder.Validate(); err != nil {
+	if err := listenerBuilder.ValidateAll(); err != nil {
 		l.Error(err, "Failed validation for the Listener", "fleet", fleetIDstr)
 		return fmt.Errorf("failed validation for Listener")
 

--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -714,7 +714,7 @@ func generateRoute(
 	if websocket != nil && *websocket {
 		routeRoute.Route.UpgradeConfigs = append(routeRoute.Route.UpgradeConfigs, &route.RouteAction_UpgradeConfig{UpgradeType: "websocket"})
 	}
-	if err := routeRoute.Route.Validate(); err != nil {
+	if err := routeRoute.Route.ValidateAll(); err != nil {
 		return nil, fmt.Errorf("incorrect Route Action: %w", err)
 	}
 

--- a/internal/envoy/config/hcm.go
+++ b/internal/envoy/config/hcm.go
@@ -146,8 +146,8 @@ func (h *HCMBuilder) AppendFilterHTTPExternalAuthorizationFilterToStart(anyAutho
 	)
 }
 
-func (h *HCMBuilder) Validate() error {
-	return h.HTTPConnectionManager.Validate()
+func (h *HCMBuilder) ValidateAll() error {
+	return h.HTTPConnectionManager.ValidateAll()
 }
 
 func (h *HCMBuilder) AddAccessLog(al *accesslog.AccessLog) *HCMBuilder {

--- a/internal/envoy/config/listener.go
+++ b/internal/envoy/config/listener.go
@@ -48,8 +48,8 @@ type listenerBuilder struct {
 	lr *listener.Listener
 }
 
-func (l *listenerBuilder) Validate() error {
-	return l.lr.Validate()
+func (l *listenerBuilder) ValidateAll() error {
+	return l.lr.ValidateAll()
 }
 
 func NewListenerBuilder() *listenerBuilder {
@@ -108,7 +108,7 @@ func makeHTTPSFilterChain(
 		},
 	}
 
-	if err := tlsCert.Validate(); err != nil {
+	if err := tlsCert.ValidateAll(); err != nil {
 		return nil, fmt.Errorf("invalid tls certificate: %w", err)
 	}
 
@@ -119,7 +119,7 @@ func makeHTTPSFilterChain(
 		},
 	}
 
-	if err := tlsDownstreamContext.Validate(); err != nil {
+	if err := tlsDownstreamContext.ValidateAll(); err != nil {
 		return nil, fmt.Errorf("invalid tls downstream context: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func getTLSParameters(tlsConfig TLS) (*tls.TlsParameters, error) {
 		tlsParams.TlsMaximumProtocolVersion = tls.TlsParameters_TlsProtocol(tlsProtocolValue)
 	}
 
-	if err := tlsParams.Validate(); err != nil {
+	if err := tlsParams.ValidateAll(); err != nil {
 		return nil, fmt.Errorf("invalid tls parameters: %w", err)
 	}
 

--- a/internal/envoy/config/logging.go
+++ b/internal/envoy/config/logging.go
@@ -85,8 +85,8 @@ type AccessLogBuilder struct {
 	al *accesslog.AccessLog
 }
 
-func (a *AccessLogBuilder) Validate() error {
-	return a.al.Validate()
+func (a *AccessLogBuilder) ValidateAll() error {
+	return a.al.ValidateAll()
 }
 
 func (a *AccessLogBuilder) GetAccessLog() *accesslog.AccessLog {
@@ -109,6 +109,7 @@ func NewJSONAccessLog(template map[string]string) (*AccessLogBuilder, error) {
 			return nil, fmt.Errorf("cannot convert log format template to struct")
 		}
 	}
+
 	accessLogFormatString := &core.SubstitutionFormatString{
 		Format: &core.SubstitutionFormatString_JsonFormat{
 			JsonFormat: formatTemplate,
@@ -156,8 +157,7 @@ func accessLogFinalize(accessLogFormatString *core.SubstitutionFormatString) (*A
 			TypedConfig: anyAccessLog,
 		},
 	}
-
-	if err := accessLog.Validate(); err != nil {
+	if err := accessLog.ValidateAll(); err != nil {
 		return nil, fmt.Errorf("failed validation of the new access log: %w", err)
 	}
 

--- a/internal/envoy/types/cors.go
+++ b/internal/envoy/types/cors.go
@@ -54,7 +54,7 @@ func GenerateCORSPolicy(
 		}
 	}
 
-	if err := corsPolicy.Validate(); err != nil {
+	if err := corsPolicy.ValidateAll(); err != nil {
 		return nil, fmt.Errorf("unable to validate cors policy: %w", err)
 	}
 

--- a/internal/envoy/types/redirect.go
+++ b/internal/envoy/types/redirect.go
@@ -137,7 +137,7 @@ func (r *RouteRedirectBuilder) StripQuery(stripQuery *bool) *RouteRedirectBuilde
 }
 
 func (r *RouteRedirectBuilder) ValidateAndReturn() (*route.Route_Redirect, error) {
-	if err := r.redirect.Redirect.Validate(); err != nil {
+	if err := r.redirect.Redirect.ValidateAll(); err != nil {
 		return nil, fmt.Errorf("failed to build Route_Redirect: %w", err)
 	}
 


### PR DESCRIPTION
In places where `Validate()` was called use `ValidateAll()` instead.

`development/cluster/create-env.sh`:

* Slight refactor of the file.
* Allow configuring `minikube` with `metrics-server`, if `METRICS=1` is set.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
