### PR TITLE
CLI: API wizard

### DIFF
--- a/cmd/kusk/cmd/docs.go
+++ b/cmd/kusk/cmd/docs.go
@@ -32,7 +32,7 @@ import (
 // apiCmd represents the api command
 var docsCmd = &cobra.Command{
 	Use:   "docs",
-	Short: "parent command for api related functions",
+	Short: "Command to generate CLI documentation",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := cmd.Root()

--- a/cmd/kusk/cmd/generate.go
+++ b/cmd/kusk/cmd/generate.go
@@ -351,7 +351,7 @@ func init() {
 		"apply",
 		"a",
 		false,
-		"to automatically apply the manifest to the cluster set value to true. Default: false",
+		"to automatically apply the manifest to the cluster. Default: false",
 	)
 
 	generateCmd.Flags().StringVarP(

--- a/cmd/kusk/docs/kusk.md
+++ b/cmd/kusk/docs/kusk.md
@@ -15,7 +15,7 @@
 * [kusk api](kusk_api.md)	 - parent command for api related functions
 * [kusk completion](kusk_completion.md)	 - Generate the autocompletion script for the specified shell
 * [kusk dashboard](kusk_dashboard.md)	 - Access the kusk dashboard
-* [kusk docs](kusk_docs.md)	 - parent command for api related functions
+* [kusk docs](kusk_docs.md)	 - Command to generate CLI documentation
 * [kusk install](kusk_install.md)	 - Install kusk-gateway, envoy-fleet, api, and dashboard in a single command
 * [kusk mock](kusk_mock.md)	 - Spin up a local mocking server serving your API
 * [kusk upgrade](kusk_upgrade.md)	 - Upgrade kusk-gateway, envoy-fleet, api, and dashboard in a single command

--- a/cmd/kusk/docs/kusk_api_generate.md
+++ b/cmd/kusk/docs/kusk_api_generate.md
@@ -71,12 +71,14 @@ kusk api generate [flags]
 ### Options
 
 ```
+  -a, --apply                         to automatically apply the manifest to the cluster. Default: false
       --envoyfleet.name string        name of envoyfleet to use for this API
       --envoyfleet.namespace string   namespace of envoyfleet to use for this API. Default: kusk-system (default "kusk-system")
   -h, --help                          help for generate
   -i, --in string                     file path or URL to OpenAPI spec file to generate mappings from. e.g. --in apispec.yaml
       --name string                   the name to give the API resource e.g. --name my-api
   -n, --namespace string              the namespace of the API resource e.g. --namespace my-namespace, -n my-namespace (default "default")
+  -o, --output string                 path to the location where to save the output of the command
       --upstream.namespace string     namespace of upstream service (default "default")
       --upstream.port uint32          port of upstream service (default 80)
       --upstream.service string       name of upstream service

--- a/cmd/kusk/docs/kusk_completion_bash.md
+++ b/cmd/kusk/docs/kusk_completion_bash.md
@@ -21,7 +21,7 @@ To load completions for every new session, execute once:
 
 #### macOS:
 
-	kusk completion bash > /usr/local/etc/bash_completion.d/kusk
+	kusk completion bash > $(brew --prefix)/etc/bash_completion.d/kusk
 
 You will need to start a new shell for this setup to take effect.
 

--- a/cmd/kusk/docs/kusk_completion_zsh.md
+++ b/cmd/kusk/docs/kusk_completion_zsh.md
@@ -11,6 +11,10 @@ to enable it.  You can execute the following once:
 
 	echo "autoload -U compinit; compinit" >> ~/.zshrc
 
+To load completions in your current shell session:
+
+	source <(kusk completion zsh); compdef _kusk kusk
+
 To load completions for every new session, execute once:
 
 #### Linux:
@@ -19,7 +23,7 @@ To load completions for every new session, execute once:
 
 #### macOS:
 
-	kusk completion zsh > /usr/local/share/zsh/site-functions/_kusk
+	kusk completion zsh > $(brew --prefix)/share/zsh/site-functions/_kusk
 
 You will need to start a new shell for this setup to take effect.
 

--- a/cmd/kusk/docs/kusk_dashboard.md
+++ b/cmd/kusk/docs/kusk_dashboard.md
@@ -42,7 +42,7 @@ kusk dashboard [flags]
       --envoyfleet.namespace string   kusk gateway dashboard envoy fleet namespace (default "kusk-system")
       --external-port int             external port to access dashboard at (default 8080)
   -h, --help                          help for dashboard
-      --kubeconfig string             absolute path to kube config (default "$HOME/.kube/config")
+      --kubeconfig string             absolute path to kube config (default "/root/.kube/config")
 ```
 
 ### Options inherited from parent commands

--- a/cmd/kusk/docs/kusk_docs.md
+++ b/cmd/kusk/docs/kusk_docs.md
@@ -1,6 +1,6 @@
 ## kusk docs
 
-parent command for api related functions
+Command to generate CLI documentation
 
 ```
 kusk docs [flags]

--- a/cmd/kusk/internal/utils/utils.go
+++ b/cmd/kusk/internal/utils/utils.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"os"
+	"path"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	kuskv1 "github.com/kubeshop/kusk-gateway/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetK8sClient() (client.Client, error) {
+	scheme := runtime.NewScheme()
+	kuskv1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+
+	config, err := getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(config, client.Options{Scheme: scheme})
+}
+
+func getConfig() (*rest.Config, error) {
+	var err error
+	var config *rest.Config
+	k8sConfigExists := false
+	homeDir, _ := os.UserHomeDir()
+	cubeConfigPath := path.Join(homeDir, ".kube/config")
+
+	if _, err := os.Stat(cubeConfigPath); err == nil {
+		k8sConfigExists = true
+	}
+
+	if cfg, exists := os.LookupEnv("KUBECONFIG"); exists {
+		config, err = clientcmd.BuildConfigFromFlags("", cfg)
+	} else if k8sConfigExists {
+		config, err = clientcmd.BuildConfigFromFlags("", cubeConfigPath)
+	} else {
+		config, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return nil, err
+	}
+	// default query per second is set to 5
+	config.QPS = 40.0
+	// default burst is set to 10
+	config.Burst = 400.0
+
+	return config, err
+}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -143,6 +144,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang/protobuf v1.5.2
+	github.com/manifoldco/promptui v0.9.0
 	go.uber.org/zap v1.21.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,11 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
@@ -488,6 +491,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -929,6 +934,7 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>

It partially fixes issue described here -> https://github.com/kubeshop/kusk-gateway/issues/328#issuecomment-1203975436

This PR allows user to pick an envoyfleet when using `kusk api generate`. 

```
# kusk api generate   -i ../../examples/todomvc/spec/todospec.yaml  
1. default/default
2. default/test
Please pick a fleet from the list above: 1

---
apiVersion: gateway.kusk.io/v1alpha1
kind: API
metadata:
  name: Todo-Backend API
  namespace: default
spec:
  fleet:
    name: default
    namespace: default
  spec: |
    components:
<redacted> 
```
Also added in this PR is option `--apply`, `-a` which allows users to apply the newly generated manifest directly from the CLI 

```
# kusk api generate   -i ../../examples/todomvc/spec/todospec.yaml  -a --name totobackend
Envoyfleets:
1. default/default
2. default/test
Please pick a fleet from the list above: 1
Do you want to proceed apply provide API to your cluster: 
api.gateway.kusk.io/totobackend created
```

Another option added in this PR is option `--output` or `-o` which allows users to specify the path where the newly generated manifest will be saved

```
$ kusk api generate   -i ../../examples/todomvc/spec/todospec.yaml  -o test.yamlEnvoyfleets:
1. default/default
2. default/test
Please pick a fleet from the list above: 1
Successfully saved the API to "test.yaml"
```
The main reason for adding output option is that funneling output of the CLI command into a file like `kusk api generate ... > file.yaml` is no longer possible because of the newly added prompts.

This is far from perfect solution so please chime in

## Checklist

- [x] tested locally
- [x] added new dependencies
- [x] updated the docs
- [ ] added a test
