### PR TITLE
added default field to envoyfleet resource

### DIFF
--- a/api/v1alpha1/envoyfleet_types.go
+++ b/api/v1alpha1/envoyfleet_types.go
@@ -39,21 +39,28 @@ type EnvoyFleetSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// Default marks fleet as the default one in the cluster
+	Default bool `json:"default,omitempty"`
+
 	// Service describes Envoy K8s service settings
 	Service *ServiceConfig `json:"service"`
 
 	// Envoy image tag
-	Image string `json:"image"`
+	Image string `json:"image,omitempty"`
+
 	// Node Selector is used to schedule the Envoy pod(s) to the specificly labeled nodes, optional
 	// This is the map of "key: value" labels (e.g. "disktype": "ssd")
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// Affinity is used to schedule Envoy pod(s) to specific nodes, optional
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+
 	// Tolerations allow pod to be scheduled to the nodes that has specific toleration labels, optional
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
 	// Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
 	// Value must be non-negative integer. The value zero indicates stop immediately via
 	// the kill signal (no opportunity to shut down).
@@ -64,9 +71,11 @@ type EnvoyFleetSpec struct {
 	// Defaults to 30 seconds.
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
 	// Additional Envoy Deployment annotations, optional
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// Resources allow to set CPU and Memory resource requests and limits, optional
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/config/crd/bases/gateway.kusk.io_envoyfleet.yaml
+++ b/config/crd/bases/gateway.kusk.io_envoyfleet.yaml
@@ -888,6 +888,9 @@ spec:
                   type: string
                 description: Additional Envoy Deployment annotations, optional
                 type: object
+              default:
+                description: Default marks fleet as the default one in the cluster
+                type: boolean
               image:
                 description: Envoy image tag
                 type: string
@@ -1133,7 +1136,6 @@ spec:
                   type: object
                 type: array
             required:
-            - image
             - service
             type: object
           status:

--- a/config/samples/gateway_v1_envoyfleet.yaml
+++ b/config/samples/gateway_v1_envoyfleet.yaml
@@ -4,6 +4,7 @@ metadata:
   name: default
 spec:
   image: "docker.io/envoyproxy/envoy:v1.23.0"
+  default: true
   service:
     # NodePort, ClusterIP, LoadBalancer
     type: LoadBalancer


### PR DESCRIPTION
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>

This PR extends envoyfleet CRD with additional field 
```
	Default bool `json:"default,omitempty"`
```

To accommodate this functionality validating webhook has been altered so it checks if there is already a default fleet existing in the same namespace. 

Please kick the tyres 

p.s. this is not going to pass CI as it  requires update to the helm charts so for the time being let it sit like this. 