### PR TITLE
changed analytics property

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -44,7 +44,7 @@ var (
 
 func SendAnonymousInfo(ctx context.Context, client client.Client, event string, message string) error {
 	properties := analytics.NewProperties()
-	properties.Set("event", message)
+	properties.Set("message", message)
 	properties.Set("version", build.Version)
 
 	track := analytics.Track{


### PR DESCRIPTION
This PR changed analytics property from event to message so we don't lose information about kusk operation executed

It fixes problem mentioned here https://github.com/kubeshop/kusk-gateway/issues/427#issuecomment-1205721824

As shown in the screenshot PG database will have aditional field "message" that will hold information like "reconciling API" which was not persisted before.

![image](https://user-images.githubusercontent.com/8327751/183048772-6c4a781f-de17-472e-ba9c-98acb66beb87.png)

Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>
