### PR TITLE
Output helm warnings on kusk install/upgrade instead of erroring out

### DIFF
--- a/cmd/kusk/cmd/upgrade.go
+++ b/cmd/kusk/cmd/upgrade.go
@@ -162,7 +162,7 @@ var upgradeCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
 
-	upgradeCmd.Flags().StringVar(&releaseName, "name", "kusk-gateway", "namespace to upgrade in")
+	upgradeCmd.Flags().StringVar(&releaseName, "name", "kusk-gateway", "name of release to update")
 	upgradeCmd.Flags().StringVar(&releaseNamespace, "namespace", "kusk-system", "namespace to upgrade in")
 	upgradeCmd.Flags().BoolVar(&installOnUpgrade, "install", false, "install components if not installed")
 }

--- a/docs/docs_root/cli/overview.md
+++ b/docs/docs_root/cli/overview.md
@@ -29,7 +29,7 @@ You can get a list of the available Kusk Gateway versions from our [releases pag
 Install `kusk` into `/usr/local/bin/kusk`:
 
 ```sh
-bash < <(curl -sSLf https://raw.githubusercontent.com/kubeshop/kusk/main/scripts/install.sh)
+bash < <(curl -sSLf https://raw.githubusercontent.com/kubeshop/kusk-gateway/main/cmd/kusk/scripts/install.sh)
 ```
 
 ### **From Source**

--- a/docs/docs_root/getting-started/installation.md
+++ b/docs/docs_root/getting-started/installation.md
@@ -20,7 +20,7 @@ Tools needed for the installation:
 You can find other installation methods (like Homebrew) [here](../cli/overview.md).
 
 ```sh
-bash < <(curl -sSLf https://raw.githubusercontent.com/kubeshop/kusk/main/scripts/install.sh)
+bash < <(curl -sSLf https://raw.githubusercontent.com/kubeshop/kusk-gateway/main/cmd/kusk/scripts/install.sh)
 ```
 
 ### **2. Install Kusk Gateway**


### PR DESCRIPTION
This PR fixes the issue where the install and upgrade commands will fail if there is a warning from helm since it couldn't parse the output when listing releases.

## Changes

- parse any stderr messages from helm. If it's a warning, output them, otherwise return the error

## Fixes

- issue where kusk install or upgrade would crash if helm returned an error

## Example
```
➜ go run main.go install
  ✔  Looking for Helm...
  ✔  Adding Kubeshop repository...
  ✔  Fetching the latest charts...
 WARNING  WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/kylehodgetts/.kube/config
          WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/kylehodgetts/.kube/config
  •  Kusk Gateway already installed, skipping... To upgrade to a new version run `kusk upgrade`
  •  Envoy Fleet already installed, skipping. To upgrade to a new version run `kusk upgrade`
  •  Private Envoy Fleet already installed, skipping. To upgrade to a new version run `kusk upgrade`
  •  api already installed, skipping. To upgrade to a new version run kusk upgrade
  •  Kusk Dashboard already installed, skipping. To upgrade to a new version run `kusk upgrade`
  •  To access the dashboard , port forward to the envoy-fleet service that exposes it
       	$ kubectl port-forward -n kusk-system svc/kusk-gateway-private-envoy-fleet 8080:80
       	and go http://localhost:8080/
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
