### PR TITLE
CLI validate specs before parsing it

### DIFF
--- a/cmd/kusk/cmd/generate.go
+++ b/cmd/kusk/cmd/generate.go
@@ -136,6 +136,17 @@ var generateCmd = &cobra.Command{
 			name = strings.ReplaceAll(parsedApiSpec.Info.Title, ".", "-")
 		}
 
+		opts, err := spec.GetOptions(parsedApiSpec)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		if err := opts.Validate(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
 		// override top level upstream service if undefined.
 		if serviceName != "" && serviceNamespace != "" && servicePort != 0 {
 			xKusk := parsedApiSpec.ExtensionProps.Extensions["x-kusk"].(options.Options)

--- a/cmd/kusk/cmd/root.go
+++ b/cmd/kusk/cmd/root.go
@@ -41,7 +41,7 @@ var rootCmd = &cobra.Command{
 	Use:   "kusk",
 	Short: "",
 	Long:  ``,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		analytics.SendAnonymousCMDInfo()
 	},
 }


### PR DESCRIPTION
CLI was only checking for yaml syntax but it was never doing logical checks. 
Without logical checks we would end up in situations like described in #520 

With this implementation CLI will output errors like this:

```
# go run cmd/kusk/main.go api generate -i test.yaml  | kubectl apply -f - 
OperationFinalSubOptions: (POST/validated: validation and mocking are mutually exclusive.).
exit status 1
error: no objects passed to apply
```

Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>

Fixes #520 #559 