### PR TITLE
CMD kusk dashboard - read kubeconfig from ENV and then from file before setting up port-forwading

### DIFF
--- a/cmd/kusk/docs/kusk_api_generate.md
+++ b/cmd/kusk/docs/kusk_api_generate.md
@@ -20,7 +20,8 @@ Generate a Kusk Gateway API resource from your OpenAPI spec file
 	You must specify the name of the envoyfleet you wish to use to expose your API. This is because Kusk Gateway could be managing more than one.
 	In the future, we will add the notion of a default envoyfleet which kusk gateway will use when none is specified.
 
-	If you do not specify the envoyfleet namespace, it will default to kusk-system.
+	In case you don't specify envoyfleet name, it will default to kusk-gateway-envoy-fleet.
+	If you do not specify the envoyfleet namespace, it will default to kusk-system. 
 
 	Sample usage
 
@@ -71,7 +72,7 @@ kusk api generate [flags]
 ### Options
 
 ```
-      --envoyfleet.name string        name of envoyfleet to use for this API
+      --envoyfleet.name string        name of envoyfleet to use for this API. Default: kusk-gateway-envoy-fleet (default "kusk-gateway-envoy-fleet")
       --envoyfleet.namespace string   namespace of envoyfleet to use for this API. Default: kusk-system (default "kusk-system")
   -h, --help                          help for generate
   -i, --in string                     file path or URL to OpenAPI spec file to generate mappings from. e.g. --in apispec.yaml

--- a/cmd/kusk/docs/kusk_completion_bash.md
+++ b/cmd/kusk/docs/kusk_completion_bash.md
@@ -21,7 +21,7 @@ To load completions for every new session, execute once:
 
 #### macOS:
 
-	kusk completion bash > /usr/local/etc/bash_completion.d/kusk
+	kusk completion bash > $(brew --prefix)/etc/bash_completion.d/kusk
 
 You will need to start a new shell for this setup to take effect.
 

--- a/cmd/kusk/docs/kusk_completion_zsh.md
+++ b/cmd/kusk/docs/kusk_completion_zsh.md
@@ -11,6 +11,10 @@ to enable it.  You can execute the following once:
 
 	echo "autoload -U compinit; compinit" >> ~/.zshrc
 
+To load completions in your current shell session:
+
+	source <(kusk completion zsh); compdef _kusk kusk
+
 To load completions for every new session, execute once:
 
 #### Linux:
@@ -19,7 +23,7 @@ To load completions for every new session, execute once:
 
 #### macOS:
 
-	kusk completion zsh > /usr/local/share/zsh/site-functions/_kusk
+	kusk completion zsh > $(brew --prefix)/share/zsh/site-functions/_kusk
 
 You will need to start a new shell for this setup to take effect.
 

--- a/cmd/kusk/docs/kusk_dashboard.md
+++ b/cmd/kusk/docs/kusk_dashboard.md
@@ -28,10 +28,6 @@ kusk dashboard [flags]
 	$ kusk dashboard --external-port=9090
 
 	Expose dashboard on port 9090
-
-	$ kusk dashboard --kubeconfig=/path/to/kube/config
-
-	Specify path to kube config. $HOME/.kube/config is used by default.
 	
 ```
 
@@ -42,7 +38,6 @@ kusk dashboard [flags]
       --envoyfleet.namespace string   kusk gateway dashboard envoy fleet namespace (default "kusk-system")
       --external-port int             external port to access dashboard at (default 8080)
   -h, --help                          help for dashboard
-      --kubeconfig string             absolute path to kube config (default "$HOME/.kube/config")
 ```
 
 ### Options inherited from parent commands

--- a/cmd/kusk/docs/kusk_upgrade.md
+++ b/cmd/kusk/docs/kusk_upgrade.md
@@ -29,7 +29,7 @@ kusk upgrade [flags]
 ```
   -h, --help               help for upgrade
       --install            install components if not installed
-      --name string        installation name (default "kusk-gateway")
+      --name string        name of release to update (default "kusk-gateway")
       --namespace string   namespace to upgrade in (default "kusk-system")
 ```
 

--- a/cmd/kusk/k8s/kubeconfig.go
+++ b/cmd/kusk/k8s/kubeconfig.go
@@ -1,0 +1,26 @@
+package k8s
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func GetKubeConfig() (string, error) {
+	if kubeconfig, ok := os.LookupEnv("KUBECONFIG"); ok {
+		if kubeconfig == "" {
+			return "", errors.New("env var KUBECONFIG set but is empty")
+		}
+
+		return kubeconfig, nil
+	}
+
+	var homeDir string
+	if h := os.Getenv("HOME"); h != "" {
+		homeDir = h
+	} else {
+		homeDir = os.Getenv("USERPROFILE") // windows
+	}
+
+	return filepath.Join(homeDir, ".kube", "config"), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.34.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/pterm/pterm v0.12.45 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
@@ -149,6 +148,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang/protobuf v1.5.2
+	github.com/pterm/pterm v0.12.45
 	go.uber.org/zap v1.21.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/MarvinJWendt/testza v0.2.8/go.mod h1:nwIcjmr0Zz+Rcwfh3/4UhBp7ePKVhuBE
 github.com/MarvinJWendt/testza v0.2.10/go.mod h1:pd+VWsoGUiFtq+hRKSU1Bktnn+DMCSrDrXDpX2bG66k=
 github.com/MarvinJWendt/testza v0.2.12/go.mod h1:JOIegYyV7rX+7VZ9r77L/eH6CfJHHzXjB69adAhzZkI=
 github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/2oUqKc6bF2c=
+github.com/MarvinJWendt/testza v0.4.2 h1:Vbw9GkSB5erJI2BPnBL9SVGV9myE+XmUSFahBGUhW2Q=
 github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
@@ -475,9 +476,11 @@ github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
+github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -512,7 +515,6 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -669,7 +671,6 @@ github.com/segmentio/backo-go v1.0.0/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As
 github.com/segmentio/conf v1.2.0/go.mod h1:Y3B9O/PqqWqjyxyWWseyj/quPEtMu1zDp/kVbSWWaB0=
 github.com/segmentio/go-snakecase v1.1.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
 github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
This PR...

## Changes

- remove kubeconfig flag for specifying custom kubeconfig location

## Fixes

- user can now run `kusk dashboard` with `KUBECONFIG` env set

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
