### PR TITLE
Upgrade Envoy to `v1.23.1`: Fixes issue with arm64 image

### DIFF
--- a/config/samples/gateway_v1_envoyfleet.yaml
+++ b/config/samples/gateway_v1_envoyfleet.yaml
@@ -3,7 +3,7 @@ kind: EnvoyFleet
 metadata:
   name: default
 spec:
-  image: "docker.io/envoyproxy/envoy:v1.23.0"
+  image: "docker.io/envoyproxy/envoy:v1.23.1"
   default: true
   service:
     # NodePort, ClusterIP, LoadBalancer


### PR DESCRIPTION
See:

* [`docker.io/envoyproxy/envoy:v1.23.0` `arm64` image fails with `./docker-entrypoint.sh: 29: exec: su-exec: Exec format error`](https://github.com/envoyproxy/envoy/issues/22384).
* [repo: Release 1.23.1](https://github.com/envoyproxy/envoy/pull/22813).

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

Test:

```sh
$ uname -a
Linux arm64-oracle 5.15.0-1016-oracle #20-Ubuntu SMP Mon Aug 8 07:08:08 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
$ docker run --rm -it --entrypoint=envoy docker.io/envoyproxy/envoy:v1.23.1 --version

envoy  version: edd69583372955fdfa0b8ca3820dd7312c094e46/1.23.1/Clean/RELEASE/BoringSSL
```

---

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
