### PR TITLE
skipping when trying to watch URLs

### DIFF
--- a/cmd/kusk/cmd/deploy.go
+++ b/cmd/kusk/cmd/deploy.go
@@ -119,12 +119,8 @@ var deployCmd = &cobra.Command{
 		if _, e := url.ParseRequestURI(file); e != nil {
 			if watch {
 				var watcher *filewatcher.FileWatcher
-				absoluteApiSpecPath := file
-				if err != nil {
-					return err
-				}
 
-				watcher, err = filewatcher.New(absoluteApiSpecPath)
+				watcher, err = filewatcher.New(file)
 				if err != nil {
 					return err
 				}
@@ -143,7 +139,7 @@ var deployCmd = &cobra.Command{
 						}
 						api := &v1alpha1.API{}
 						if err := yaml.Unmarshal([]byte(manifest), api); err != nil {
-							ui.Info("there has been an error in API manifest", err.Error())
+							ui.Err(err)
 						}
 
 						if len(api.Namespace) == 0 {


### PR DESCRIPTION
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>

This PR fixes remark https://github.com/kubeshop/kusk-gateway/pull/679#issuecomment-1235559712
and 
closes  #682 

when trying to watch a URL a warning message is printed out
```
# go run cmd/kusk/main.go deploy -i https://raw.githubusercontent.com/kubeshop/kuskgateway-api-server/main/api/openapi.yaml to watcher: lstat https:/raw.githubusercontent.com/kubeshop/kuskgateway-api-server/main/api/openapi.yaml  --name test   -w
api.gateway.kusk.io/test updated
Warning: cannot watch URL. '--watch, -w' flag ignored!
```