### PR TITLE
691 - CLI: Allow external schema refs

### DIFF
--- a/api/v1alpha1/api_webhook.go
+++ b/api/v1alpha1/api_webhook.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -147,9 +148,9 @@ func (a *APIValidator) InjectDecoder(d *admission.Decoder) error {
 }
 
 func (r *API) validate() error {
-	parser := spec.NewParser(nil)
-
-	apiSpec, err := parser.ParseFromReader(strings.NewReader(r.Spec.Spec))
+	apiSpec, err := spec.
+		NewParser(&openapi3.Loader{IsExternalRefsAllowed: true}).
+		ParseFromReader(strings.NewReader(r.Spec.Spec))
 	if err != nil {
 		return fmt.Errorf("spec: should be a valid OpenAPI spec: %w", err)
 	}

--- a/cmd/kusk/cmd/generate.go
+++ b/cmd/kusk/cmd/generate.go
@@ -127,7 +127,7 @@ var generateCmd = &cobra.Command{
 			}
 		}
 
-		parsedApiSpec, err := spec.NewParser(openapi3.NewLoader()).Parse(apiSpecPath)
+		parsedApiSpec, err := spec.NewParser(&openapi3.Loader{IsExternalRefsAllowed: true}).Parse(apiSpecPath)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			reportError(err)

--- a/cmd/kusk/cmd/mock.go
+++ b/cmd/kusk/cmd/mock.go
@@ -141,7 +141,7 @@ $ kusk mock -i https://url.to.api.com
 			ui.Fail(err)
 		}
 
-		spec, err := spec.NewParser(openapi3.NewLoader()).Parse(apiSpecPath)
+		spec, err := spec.NewParser(&openapi3.Loader{IsExternalRefsAllowed: true}).Parse(apiSpecPath)
 		if err != nil {
 			err := fmt.Errorf("error when parsing openapi spec: %w", err)
 			reportError(err)

--- a/cmd/kusk/internal/mocking/mocking.go
+++ b/cmd/kusk/internal/mocking/mocking.go
@@ -7,7 +7,7 @@ import (
 const openApiMockingConfigStr = `application:
   debug: false
   log_format: json
-  log_level: warn
+  log_level: info
 
 generation:
   suppress_errors: false

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,6 +35,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/kelseyhightower/envconfig"
@@ -65,6 +66,7 @@ import (
 	"github.com/kubeshop/kusk-gateway/internal/validation"
 	"github.com/kubeshop/kusk-gateway/internal/webhooks"
 	"github.com/kubeshop/kusk-gateway/pkg/analytics"
+	"github.com/kubeshop/kusk-gateway/pkg/spec"
 )
 
 var (
@@ -272,7 +274,9 @@ func main() {
 		Validator:          proxy,
 		SecretToEnvoyFleet: map[string]gateway.EnvoyFleetID{},
 		WatchedSecretsChan: secretsChan,
+		OpenApiParser:      spec.NewParser(&openapi3.Loader{IsExternalRefsAllowed: true}),
 	}
+
 	analytics.SendAnonymousInfo(ctx, controllerConfigManager.Client, "kusk", "kusk-gateway manager bootstrapping")
 	heartBeat(ctx, controllerConfigManager.Client)
 

--- a/internal/controllers/config_manager.go
+++ b/internal/controllers/config_manager.go
@@ -61,6 +61,8 @@ type KubeEnvoyConfigManager struct {
 
 	WatchedSecretsChan chan *v1.Secret
 	SecretToEnvoyFleet map[string]gateway.EnvoyFleetID
+
+	OpenApiParser spec.Parser
 }
 
 var (
@@ -97,10 +99,9 @@ func (c *KubeEnvoyConfigManager) UpdateConfiguration(ctx context.Context, fleetI
 	}
 
 	clBuilder := cloudentity.NewBuilder()
-	parser := spec.NewParser(nil)
 	for _, api := range apis {
 		l.Info("Processing API configuration", "fleet", fleetIDstr, "api", api.Name)
-		apiSpec, err := parser.ParseFromReader(strings.NewReader(api.Spec.Spec))
+		apiSpec, err := c.OpenApiParser.ParseFromReader(strings.NewReader(api.Spec.Spec))
 		if err != nil {
 			return fmt.Errorf("failed to parse OpenAPI spec: %w", err)
 		}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -128,7 +128,7 @@ func parseSwagger(spec []byte) (*openapi3.T, error) {
 }
 
 func parseOpenAPI3(spec []byte) (*openapi3.T, error) {
-	return openapi3.NewLoader().LoadFromData(spec)
+	return (&openapi3.Loader{IsExternalRefsAllowed: true}).LoadFromData(spec)
 }
 
 // GetExampleResponse returns a single example response from the given operation


### PR DESCRIPTION
## Summary

Given an OpenAPI file such as the following:
```
openapi: 3.0.0
info:
  title: my-api
  version: 0.0.0
paths:
  /foo:
    get:
      responses:
        '200':
          description: Some description value text
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: 'https://examplecom#/components/schemas/SomeSchema'
```

and the schema file with the following contents
```
components:
  schemas:
    SomeSchema:
      required:
        - name
      type: object
      properties:
        id:
          type: string
        name:
          type: string
```
The CLI will follow the external OpenAPI schema references from other relative files or from a URL.

## Mocking
The mock server (`kusk mock -i ...`) can now serve mock responses based on external schemas.

### Limitations
Kusk Gateway mocking currently doesn't support any mocking from schema. Once this is implemented, there will still be a limitation on relative file references due to the "lack" of a file system in K8s. 

We could potentially get around this by allowing `kusk generate` to follow the references and bring the remote references into the API resource locally.

HTTP references should work as advertised once implemented