### PR TITLE
CLI Help: Hide docs if unused

### DIFF
--- a/cmd/kusk/cmd/docs.go
+++ b/cmd/kusk/cmd/docs.go
@@ -39,6 +39,7 @@ var docsCmd = &cobra.Command{
 		root.DisableAutoGenTag = true
 		return doc.GenMarkdownTree(root, "docs")
 	},
+	Hidden: true,
 }
 
 func init() {


### PR DESCRIPTION
Fixes kubeshop/kusk-gateway#672.

Before, `docs` appears in list of available commands:

```sh
$ go run cmd/kusk/main.go
Usage:
  kusk [command]

Available Commands:
  api         parent command for api related functions
  completion  Generate the autocompletion script for the specified shell
  dashboard   Access the kusk dashboard
  deploy      deploy command to deploy your apis
  docs        parent command for api related functions
  help        Help about any command
  install     Install kusk-gateway, envoy-fleet, api, and dashboard in a single command
  mock        Spin up a local mocking server serving your API
  upgrade     Upgrade kusk-gateway, envoy-fleet, api, and dashboard in a single command
  version     version for kusk

Flags:
      --config string   config file (default is $HOME/.kusk.yaml)
  -h, --help            help for kusk
  -t, --toggle          Help message for toggle
  -v, --version         version for kusk
```

After, i.e., `docs` does not appear in list of available commands:

```sh
go run cmd/kusk/main.go
Usage:
  kusk [command]

Available Commands:
  api         parent command for api related functions
  completion  Generate the autocompletion script for the specified shell
  dashboard   Access the kusk dashboard
  deploy      deploy command to deploy your apis
  help        Help about any command
  install     Install kusk-gateway, envoy-fleet, api, and dashboard in a single command
  mock        Spin up a local mocking server serving your API
  upgrade     Upgrade kusk-gateway, envoy-fleet, api, and dashboard in a single command
  version     version for kusk

Flags:
      --config string   config file (default is $HOME/.kusk.yaml)
  -h, --help            help for kusk
  -t, --toggle          Help message for toggle
  -v, --version         version for kusk

Use "kusk [command] --help" for more information about a command.
```

Command is still available to run, i.e., `docs` folder is still generated:

```sh
$ go run cmd/kusk/main.go docs
$ git s
On branch main
Your branch is up-to-date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   cmd/kusk/cmd/docs.go

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	docs/kusk.md
	docs/kusk_api.md
	docs/kusk_api_generate.md
	docs/kusk_completion.md
	docs/kusk_completion_bash.md
	docs/kusk_completion_fish.md
	docs/kusk_completion_powershell.md
	docs/kusk_completion_zsh.md
	docs/kusk_dashboard.md
	docs/kusk_deploy.md
	docs/kusk_install.md
	docs/kusk_mock.md
	docs/kusk_upgrade.md
	docs/kusk_version.md
```

See: <https://github.com/kubeshop/kusk-gateway/issues/672>

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
