### PR TITLE
OAuth2: Dynamic Secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,20 +80,20 @@ tail-envoyfleet: ## Tail logs of envoy
 .PHONY: enable-logging
 enable-logging: ## Set some particular logger's level
 	kubectl port-forward --namespace default deployments/default 19000:19000 & echo $$! > /tmp/kube-port-forward-logging.pid
-	sleep 4
-	curl -s -X POST "http://localhost:19000/logging?backtrace=trace"
-	curl -s -X POST "http://localhost:19000/logging?envoy_bug=trace"
-	curl -s -X POST "http://localhost:19000/logging?assert=trace"
-	curl -s -X POST "http://localhost:19000/logging?secret=trace"
-	curl -s -X POST "http://localhost:19000/logging?grpc=trace"
-	curl -s -X POST "http://localhost:19000/logging?ext_authz=trace"
-	curl -s -X POST "http://localhost:19000/logging?filter=trace"
-	curl -s -X POST "http://localhost:19000/logging?misc=trace"
-	curl -s -X POST "http://localhost:19000/logging?conn_handler=trace"
-	@# curl -s -X POST "http://localhost:19000/logging?connection=trace"
-	@# curl -s -X POST "http://localhost:19000/logging?http=trace"
-	@# curl -s -X POST "http://localhost:19000/logging?http2=trace"
-	@# curl -s -X POST "http://localhost:19000/logging?admin=trace"
+	sleep 2
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?backtrace=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?envoy_bug=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?assert=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?secret=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?grpc=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?ext_authz=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?filter=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?misc=trace"
+	curl --silent --output /dev/null -X POST "http://localhost:19000/logging?conn_handler=trace"
+	@# curl --silent --output /dev/null -X POST "http://localhost:19000/logging?connection=trace"
+	@# curl --silent --output /dev/null -X POST "http://localhost:19000/logging?http=trace"
+	@# curl --silent --output /dev/null -X POST "http://localhost:19000/logging?http2=trace"
+	@# curl --silent --output /dev/null -X POST "http://localhost:19000/logging?admin=trace"
 	@# bash -c "trap 'pkill -F /tmp/kube-port-forward-logging.pid' SIGINT SIGTERM ERR EXIT"
 	@echo
 	@echo "How to stop port forward to the admin port (19000):"

--- a/config/samples/gateway_v1_envoyfleet.yaml
+++ b/config/samples/gateway_v1_envoyfleet.yaml
@@ -78,7 +78,7 @@ spec:
     # The output example:
     # "[2021-12-15T16:50:50.217Z]" "GET" "/" "200" "1"
     text_template: |
-      "[%START_TIME%]" "%REQ(:METHOD)%" "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" "%RESPONSE_CODE%" "%DURATION%"
+      "[%START_TIME%]" "%REQ(:scheme)%" "%REQ(:METHOD)%" "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" "%RESPONSE_CODE%" %BYTES_SENT% %DURATION% %UPSTREAM_HOST% %REQ(X-ENVOY-IP-TAGS)%"
     # Json format fields order isn't preserved
     # The output example:
     # {"start_time":"2021-12-15T16:46:52.135Z","path":"/","response_code":200,"method":"GET","duration":1}

--- a/docs/docs/extension.md
+++ b/docs/docs/extension.md
@@ -327,7 +327,7 @@ The `auth` object contains the following properties to configure HTTP authentica
 | `auth.oauth2.authorization_endpoint`    | **Required, if `scheme` is `oauth2`**. Defines the `authorization_endpoint`, e.g., the field `authorization_endpoint` from <https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/.well-known/openid-configuration>. |
 | `auth.oauth2.credentials.client_id`     | **Required, if `scheme` is `oauth2`**. Defines the Client ID. |
 | `auth.oauth2.credentials.client_secret` | **Required, if `scheme` is `oauth2`**. Defines the Client Secret. |
-| `auth.oauth2.redirect_uri`              | **Required, if `scheme` is `oauth2`**. The redirect URI passed to the authorization endpoint. |
+| `auth.oauth2.redirect_uri`              | **Required, if `scheme` is `oauth2`**. The redirect URI passed to the authorization endpoint. It is advised to use `%REQ(x-forwarded-proto)%://%REQ(:authority)%` before the actual callback path, e.g., the `redirect_uri` should be defined as `""%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback/oauth2/callback"`, including the quotes. |
 | `auth.oauth2.signout_path`              | **Required, if `scheme` is `oauth2`**. The path to sign a user out, clearing their credential cookies. |
 | `auth.oauth2.redirect_path_matcher`     | **Required, if `scheme` is `oauth2`**. After a redirecting the user back to the `redirect_uri`, using this new grant and the `token_secret`, the `kusk-gateway` then attempts to retrieve an access token from the `token_endpoint`. The `kusk-gateway` knows it has to do this instead of reinitiating another login because the incoming request has a path that matches the `redirect_path_matcher` criteria. |
 | `auth.oauth2.forward_bearer_token`      | **Required, if `scheme` is `oauth2`**. If the Bearer Token should be forwarded, you generally want this to be `true`. When the authn server validates the client and returns an authorization token back to `kusk-gateway`, no matter what format that token is, if `forward_bearer_token` is set to true `kusk-gateway` will send over a cookie named `BearerToken` to the upstream. Additionally, the `Authorization` header will be populated with the same value, i.e., Forward the OAuth token as a Bearer to upstream web service. |
@@ -391,7 +391,7 @@ x-kusk:
       credentials:
         client_id: *CLIENT_ID*
         client_secret: *CLIENT_SECRET*
-      redirect_uri: /oauth2/callback
+      redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback"
       redirect_path_matcher: /oauth2/callback
       signout_path: /oauth2/signout
       forward_bearer_token: true

--- a/examples/auth/oauth2/authorization-code-grant/api.yaml
+++ b/examples/auth/oauth2/authorization-code-grant/api.yaml
@@ -30,20 +30,21 @@ spec:
           credentials:
             client_id: upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8
             client_secret: Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ
-          redirect_uri: /oauth2/callback
+          #redirect_uri: "%REQ(:scheme)%://%REQ(:authority)%/oauth2/callback"
+          redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback"
           redirect_path_matcher: /oauth2/callback
           signout_path: /oauth2/signout
           forward_bearer_token: true
           auth_scopes:
             - openid
     paths:
-      "/":
-        get:
-          description: Returns GET data.
-          operationId: "/get"
-          responses: {}
       "/uuid":
         get:
           description: Returns UUID4.
           operationId: "/uuid"
           responses: {}
+      # "/":
+      #   get:
+      #     description: Returns GET data.
+      #     operationId: "/get"
+      #     responses: {}

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/gookit/color v1.5.2
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect

--- a/internal/controllers/envoy.yaml
+++ b/internal/controllers/envoy.yaml
@@ -16,23 +16,14 @@ dynamic_resources:
     ads: {}
 
 static_resources:
-  secrets:
-    - name: token
-      generic_secret:
-        secret:
-          inline_string: "<stub_token_secret>"
-    - name: hmac
-      generic_secret:
-        secret:
-          inline_bytes: "KVPwEwpMmxmqxvT+tZu07vCDwpT41/vnjeM5kLW78Vc="
   clusters:
-    - type: STRICT_DNS
+    - name: xds_cluster
+      type: STRICT_DNS
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           explicit_http_config:
             http2_protocol_options: {}
-      name: xds_cluster
       load_assignment:
         cluster_name: xds_cluster
         endpoints:

--- a/internal/envoy/config/hcm.go
+++ b/internal/envoy/config/hcm.go
@@ -239,13 +239,11 @@ func ConfigSource(cluster string) *envoy_core_v3.ConfigSource {
 		ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
 		ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_ApiConfigSource{
 			ApiConfigSource: &envoy_core_v3.ApiConfigSource{
-				TransportApiVersion:       envoy_core_v3.ApiVersion_V3,
-				ApiType:                   envoy_core_v3.ApiConfigSource_GRPC,
-				RequestTimeout:            durationpb.New(defaultRequestTimeout),
-				SetNodeOnFirstMessageOnly: true,
-				GrpcServices: []*envoy_core_v3.GrpcService{
-					makeGrpcService(cluster, "", defaultResponseTimeout),
-				},
+				TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
+				RequestTimeout:      durationpb.New(defaultRequestTimeout),
+				GrpcServices:        []*envoy_core_v3.GrpcService{makeGrpcService(cluster, "", defaultResponseTimeout)},
+				//SetNodeOnFirstMessageOnly: true, // Could someone please justify why this is set to `true`?
 			},
 		},
 	}

--- a/internal/envoy/config/resource_cache_type_utils.go
+++ b/internal/envoy/config/resource_cache_type_utils.go
@@ -1,0 +1,47 @@
+// MIT License
+//
+// Copyright (c) 2022 Kubeshop
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package config
+
+import (
+	"reflect"
+
+	cacheTypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+)
+
+// asResources casts the given slice of values (that implement the envoy_types.Resource
+// interface) to a slice of envoy_types.Resource. If the length of the slice is 0, it
+// returns nil.
+func asResources(messages interface{}) []cacheTypes.Resource {
+	v := reflect.ValueOf(messages)
+	if v.Len() == 0 {
+		return nil
+	}
+
+	protos := make([]cacheTypes.Resource, v.Len())
+
+	for i := range protos {
+		protos[i] = v.Index(i).Interface().(cacheTypes.Resource)
+	}
+
+	return protos
+}

--- a/internal/envoy/manager/cache_manager.go
+++ b/internal/envoy/manager/cache_manager.go
@@ -44,7 +44,7 @@ type cacheManager struct {
 func NewCacheManager(snapshotCache cache_v3.SnapshotCache, logger logr.Logger) *cacheManager {
 	return &cacheManager{
 		SnapshotCache: snapshotCache,
-		fleetSnapshot: make(map[string]*cache_v3.Snapshot),
+		fleetSnapshot: map[string]*cache_v3.Snapshot{},
 		mu:            sync.RWMutex{},
 		logger:        logger.WithName("CacheManager"),
 	}

--- a/internal/envoy/manager/envoy_callbacks.go
+++ b/internal/envoy/manager/envoy_callbacks.go
@@ -21,6 +21,8 @@
 // SOFTWARE.
 
 // Callbacks are called by GRPC server on new events.
+//
+// `l.logger.V(1)` is effectively debug level.
 package manager
 
 import (
@@ -56,21 +58,11 @@ func (c *Callbacks) OnDeltaStreamOpen(ctx context.Context, id int64, typeUrl str
 }
 
 func (c *Callbacks) OnDeltaStreamClosed(id int64) {
-	// `l.logger.V(1)` is effectively debug level.
 	c.logger.V(1).Info("OnDeltaStreamClosed", "id", id)
 }
 
 func (c *Callbacks) OnStreamRequest(id int64, request *envoy_discovery_v3.DiscoveryRequest) error {
-	c.logger.V(1).Info("OnStreamRequest", "id", id, "request.TypeUrl", request.TypeUrl)
-	if c.cacheManager.IsNodeExist(request.Node.Id) {
-		return nil
-	}
-
-	if err := c.cacheManager.setNodeSnapshot(request.Node.Id, request.Node.Cluster); err != nil {
-		c.logger.Error(err, "OnStreamRequest", "id", id, "request.TypeUrl", request.TypeUrl)
-		return err
-	}
-
+	c.logger.Info("OnStreamRequest", "id", id, "request.TypeUrl", request.TypeUrl, "request.Node.Cluster", request.Node.Cluster, "request.Node.Id", request.Node.Id)
 	return nil
 }
 

--- a/internal/envoy/manager/envoy_config_manager.go
+++ b/internal/envoy/manager/envoy_config_manager.go
@@ -91,11 +91,7 @@ func registerServer(grpcServer *grpc.Server, server server.Server) {
 	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
 	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)
 	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, server)
-
 	secretservice.RegisterSecretDiscoveryServiceServer(grpcServer, server)
-	// TODO(MBana): Not too sure about this one, but I'm leaving it as a reference that an unimplemented SDS could be used.
-	// secretservice.RegisterSecretDiscoveryServiceServer(grpcServer, &secretservice.UnimplementedSecretDiscoveryServiceServer{})
-
 	runtimeservice.RegisterRuntimeDiscoveryServiceServer(grpcServer, server)
 }
 

--- a/internal/envoy/types/secrets.go
+++ b/internal/envoy/types/secrets.go
@@ -1,0 +1,30 @@
+// MIT License
+//
+// Copyright (c) 2022 Kubeshop
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+type SecretType string
+
+const (
+	TokenSecretType SecretType = "token_secret"
+	HMACSecretType  SecretType = "hmac_secret"
+)

--- a/pkg/options/auth.go
+++ b/pkg/options/auth.go
@@ -168,7 +168,8 @@ type Credentials struct {
 	ClientSecret string `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
 	// REQUIRED.
 	TokenSecret string `json:"token_secret,omitempty" yaml:"token_secret,omitempty"`
-	// REQUIRED.
+	// If not specified, `kusk-gateway` generates the `hmac_secret`.
+	// OPTIONAL.
 	HmacSecret string `json:"hmac_secret,omitempty" yaml:"hmac_secret,omitempty"`
 	// OPTIONAL.
 	CookieNames CookieNames `json:"cookie_names,omitempty" yaml:"cookie_names,omitempty"`
@@ -186,10 +187,13 @@ func (o Credentials) Validate() error {
 // CookieNames - By default, OAuth2 filter sets some cookies with the following names: BearerToken, OauthHMAC, and OauthExpires. These cookie names can be customized by setting cookie_names.
 type CookieNames struct {
 	// Defaults to BearerToken.
+	// OPTIONAL.
 	BearerToken string `json:"bearer_token,omitempty" yaml:"bearer_token,omitempty"`
 	// Defaults to OauthHMAC.
+	// OPTIONAL.
 	OauthHMAC string `json:"oauth_hmac,omitempty" yaml:"oauth_hmac,omitempty"`
 	// Defaults to OauthExpires.
+	// OPTIONAL.
 	ExpiresOauth string `json:"oauth_expires,omitempty" yaml:"oauth_expires,omitempty"`
 }
 

--- a/smoketests/Makefile
+++ b/smoketests/Makefile
@@ -28,8 +28,11 @@ check-openapi-path:
 check-auth_oauth2:
 	kubectl apply -f ../examples/auth/oauth2/authorization-code-grant/manifests.yaml
 	kubectl wait deployment --namespace default auth-oauth2-oauth0-authorization-code-grant-go-httpbin --for condition=Available=True --timeout=3m
+	kubectl port-forward --namespace default deployments/default 19000:19000 & echo $$! > /tmp/kube-port-forward-check-auth_oauth2.pid
+	sleep 2
 	go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/$(subst check-,,$@)
 	kubectl delete -f ../examples/auth/oauth2/authorization-code-grant/manifests.yaml
+	bash -c "trap 'pkill -F /tmp/kube-port-forward-check-auth_oauth2.pid' SIGINT SIGTERM ERR EXIT"
 
 sandbox:
 	@docker build samples/hello-world/hello-world-container/ -t localhost:50000/hello-world:smoke


### PR DESCRIPTION
Support defining the secrets dynamically, i.e., they should appear as `dynamic_active_secrets` in the admin `/config_dump` page:

```sh
$ kubectl port-forward --namespace default deployment/default 19000:19000 &
$ curl -s 'http://localhost:19000/stats' | grep sds
sds.client_secret_test_1.version_text: "690"
sds.hmac_secret_test_1.version_text: "690"
cluster.kubeshop-kusk-gateway-oauth2.eu.auth0.com.client_ssl_socket_factory.ssl_context_update_by_sds: 0
sds.client_secret_test_1.init_fetch_timeout: 0
sds.client_secret_test_1.key_rotation_failed: 0
sds.client_secret_test_1.update_attempt: 2
sds.client_secret_test_1.update_failure: 0
sds.client_secret_test_1.update_rejected: 0
sds.client_secret_test_1.update_success: 1
sds.client_secret_test_1.update_time: 1662408207693
sds.client_secret_test_1.version: 18219575566587264222
sds.hmac_secret_test_1.init_fetch_timeout: 0
sds.hmac_secret_test_1.key_rotation_failed: 0
sds.hmac_secret_test_1.update_attempt: 2
sds.hmac_secret_test_1.update_failure: 0
sds.hmac_secret_test_1.update_rejected: 0
sds.hmac_secret_test_1.update_success: 1
sds.hmac_secret_test_1.update_time: 1662408207693
sds.hmac_secret_test_1.version: 18219575566587264222
sds.client_secret_test_1.update_duration: P0(nan,0) P25(nan,0) P50(nan,0) P75(nan,0) P90(nan,0) P95(nan,0) P99(nan,0) P99.5(nan,0) P99.9(nan,0) P100(nan,0)
sds.hmac_secret_test_1.update_duration: P0(nan,0) P25(nan,0) P50(nan,0) P75(nan,0) P90(nan,0) P95(nan,0) P99(nan,0) P99.5(nan,0) P99.9(nan,0) P100(nan,0)
$ curl -s 'http://localhost:19000/config_dump' | jq '.[] | .[-1].dynamic_active_secrets'
[
  {
    "name": "client_secret_test_1",
    "version_info": "690",
    "last_updated": "2022-09-05T20:03:27.693Z",
    "secret": {
      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
      "name": "client_secret_test_1",
      "generic_secret": {
        "secret": {
          "inline_string": "[redacted]"
        }
      }
    }
  },
  {
    "name": "hmac_secret_test_1",
    "version_info": "690",
    "last_updated": "2022-09-05T20:03:27.693Z",
    "secret": {
      "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
      "name": "hmac_secret_test_1",
      "generic_secret": {
        "secret": {
          "inline_bytes": "W3JlZGFjdGVkXQ=="
        }
      }
    }
  }
]
```

Things to note from the above output are:

1. The secrets are in the `dynamic_active_secrets` object not in a `dynamic_warming_secrets` object, the later of which would mean that the secrets have not been sent to envoy. See <https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/admin/v3/config_dump.proto#admin-v3-secretsconfigdump> for more information. As per the documentation `dynamic_active_secrets`:

> "The dynamically loaded active secrets. These are secrets that are available to service clusters or listeners."

2. The output from the `/stats` endpoint shows no failures.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

## Summary

The main changes are in:

1. `EnvoyConfiguration.GenerateSnapshot`.
2. `internal/envoy/auth/oauth2_filter.go` - use ADS as the config source.
3. `internal/envoy/config/hcm.go` - the removal of `SetNodeOnFirstMessageOnly`.
4. It's important to wait for the log line below to appear before applying changes otherwise it seems things remain in `dynamic_warming_secrets` and a restart of Envoy is required by doing `curl -X POST 'http://localhost:19000/quitquitquit` (given the port forward to the admin port is active):

```sh
kusk-system kusk-gateway-manager-778dbbbb65-jwzn8 manager {"level":"info","ts":1662412460.1216035,"logger":"CacheManager","caller":"manager/envoy_callbacks.go:65","msg":"OnStreamRequest","id":1,"request.TypeUrl":"type.googleapis.com/envoy.config.listener.v3.Listener","request.Node.Cluster":"default.default","request.Node.Id":"default-646f9677f7-kxtbw"}
```

## TODO

- [x] Update smoketests to tests that secrets are in `dynamic_active_secrets` and not in `dynamic_warming_secrets`. This just requires a `GET` on the endpoint and checking that they are indeed `dynamic_active_secrets`. Partially complete in that the structure of the test has been written.
- [ ] Update OAuth2 documentation.
- [ ] Managements of secrets when an API is deleted. The secrets defined needed to be deleted as well.
- [ ] Could someone please have a look at `internal/envoy/config/hcm.go` and tell me why `SetNodeOnFirstMessageOnly: true` is there in the first place? It seems like when it is set to true, the secrets remain in the `dynamic_warming_secrets` object which won't allow dynamic secrets to be defined.
- [ ] Document how a developer could quickly test out OAuth2.