### PR TITLE
silencing errors in the command so we don't have duplicate error output

### DIFF
--- a/cmd/kusk/cmd/deploy.go
+++ b/cmd/kusk/cmd/deploy.go
@@ -72,9 +72,10 @@ func init() {
 
 // apiCmd represents the api command
 var deployCmd = &cobra.Command{
-	Use:   "deploy",
-	Short: "deploy command to deploy your apis",
-	Long:  ``,
+	Use:           "deploy",
+	Short:         "deploy command to deploy your apis",
+	SilenceErrors: true,
+	Long:          ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		cmd.SilenceUsage = true

--- a/docs/docs/extension.md
+++ b/docs/docs/extension.md
@@ -287,7 +287,7 @@ Note: Currently, rate limiting is applied per Envoy pod - if you have more than 
 x-kusk:
   rate_limit:
     requests_per_limit: 2
-    rate_limit.unit: minute
+    unit: minute
 ...
 ```
 ### **Caching**

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -67,7 +67,7 @@ func SendAnonymousCMDInfo() error {
 	properties := analytics.NewProperties()
 	properties.Set("event", event)
 	properties.Set("command", command)
-	properties.Set("version", analytics.Version)
+	properties.Set("version", build.Version)
 	track := analytics.Track{
 		AnonymousId: MachineID(),
 		UserId:      MachineID(),


### PR DESCRIPTION
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>

This PR silences double error output. Since we are already capturing errors [here ](https://github.com/kubeshop/kusk-gateway/blob/main/cmd/kusk/cmd/root.go#L51-L53) no need to print them twice.