### PR TITLE
CLI: Move `kusk api generate` to `kusk generate` - #667

### DIFF
--- a/cmd/kusk/cmd/api.go
+++ b/cmd/kusk/cmd/api.go
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 .
 */
+
 package cmd
 
 import (
@@ -31,18 +32,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Deprecated: `kusk api generate` is deprecated, use `kusk generate` instead.
+
 // apiCmd represents the api command
 var apiCmd = &cobra.Command{
 	Use:   "api",
 	Short: "parent command for api related functions",
 	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Currently api only has one sub command
-		fmt.Fprint(os.Stderr, "The api command cannot be run directly. Please run: kusk api generate\n")
+		fmt.Fprintln(os.Stderr, "The `api` command cannot be run directly. Please run: `kusk generate`")
 
-		// In future, remove this when new sub commands are added and simply call cmd.Help()
-		generateCmd.Help()
+		return cmd.Help()
 	},
+	// > For good practice, let's keep `kusk api generate` for a release and mark it as deprecated in the help. I would normally say show a deprecated message on usage but that would defeat the purpose as it would be a breaking change since we pipe the output.
+	//
+	// See: <https://github.com/kubeshop/kusk-gateway/issues/667>.
+	Deprecated: "this command will be deprecated soon, please use `kusk generate`",
 }
 
 func init() {

--- a/cmd/kusk/cmd/generate.go
+++ b/cmd/kusk/cmd/generate.go
@@ -232,6 +232,9 @@ func getAPISpecString(apiSpec *openapi3.T) (string, error) {
 }
 
 func init() {
+	rootCmd.AddCommand(generateCmd)
+	// This should be deprecated soon.
+	// See `apiCmd.Deprecated`.
 	apiCmd.AddCommand(generateCmd)
 
 	generateCmd.Flags().StringVarP(

--- a/cmd/kusk/cmd/root.go
+++ b/cmd/kusk/cmd/root.go
@@ -93,6 +93,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		fmt.Fprintln(os.Stderr, fmt.Errorf("failed to read config file %q, %w", viper.ConfigFileUsed(), err))
 	}
 }


### PR DESCRIPTION
While the organization under `api` seems logical. We currently have only one command there and others were placed at a root level (ie. `kusk mock`). Being that we are an API developer tool, lets put all commands that would go under `api` at the root and use parents for non API related tasks.

So `kusk api generate` becomes `kusk generate`.

For good practice, let's keep `kusk api generate` for a release and mark it as deprecated in the help. I would normally say show a deprecated message on usage but that would defeat the purpose as it would be a breaking change since we pipe the output.

Also, re-run `kusk docs` to regeneraete `cmd/kusk/docs` folder.

See: <https://github.com/kubeshop/kusk-gateway/issues/667>.

Closes kubeshop/kusk-gateway/issues#667>.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

`api` no longer appears in `--help` output:

```sh
$ kusk --help 
Usage:
  kusk [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  dashboard   Access the kusk dashboard
  deploy      deploy command to deploy your apis
  generate    Generate a Kusk Gateway API resource from your OpenAPI spec file
  help        Help about any command
  install     Install kusk-gateway, envoy-fleet, api, and dashboard in a single command
  ip          return IP address of the default envoyfleet
  mock        Spin up a local mocking server serving your API
  upgrade     Upgrade kusk-gateway, envoy-fleet, api, and dashboard in a single command
  version     version for kusk

Flags:
      --config string   config file (default is $HOME/.kusk.yaml)
  -h, --help            help for kusk
  -t, --toggle          Help message for toggle
  -v, --version         version for kusk

Use "kusk [command] --help" for more information about a command.
```

When running `api --help`, command is mark as deprecated:

```sh
$ kusk api --help
Command "api" is deprecated, this command will be deprecated soon, please use `kusk generate`
parent command for api related functions

Usage:
  kusk api [flags]
  kusk api [command]

Available Commands:
  generate    Generate a Kusk Gateway API resource from your OpenAPI spec file

Flags:
  -h, --help   help for api

Global Flags:
      --config string   config file (default is $HOME/.kusk.yaml)

Use "kusk api [command] --help" for more information about a command.
```

Deprecated command still works:

```
$ kusk api generate --in apispec.yaml

---
apiVersion: gateway.kusk.io/v1alpha1
kind: API
metadata:
  name: auth-oauth2-oauth0-authorization-code-grant
  namespace: default
spec:
  fleet:
    name: kusk-gateway-envoy-fleet
    namespace: kusk-system
  spec: |
    components: {}
    info:
      description: auth-oauth2-oauth0-authorization-code-grant
      title: auth-oauth2-oauth0-authorization-code-grant
      version: 0.1.0
    openapi: 3.0.0
    paths:
      /:
        get:
          description: Returns GET data.
          operationId: /get
          responses: {}
      /uuid:
        get:
          description: Returns UUID4.
          operationId: /uuid
          responses: {}
    schemes:
    - http
    - https
    x-kusk:
      auth:
        oauth2:
          auth_scopes:
          - openid
          authorization_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/authorize
          credentials:
            client_id: upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8
            client_secret: Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ
          forward_bearer_token: true
          redirect_path_matcher: /oauth2/callback
          redirect_uri: /oauth2/callback
          signout_path: /oauth2/signout
          token_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/oauth/token
        scheme: oauth2
      upstream:
        service:
          name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
          namespace: default
          port: 80
```

New version works:

```sh
$ kusk generate --in apispec.yaml

---
apiVersion: gateway.kusk.io/v1alpha1
kind: API
metadata:
  name: auth-oauth2-oauth0-authorization-code-grant
  namespace: default
spec:
  fleet:
    name: kusk-gateway-envoy-fleet
    namespace: kusk-system
  spec: |
    components: {}
    info:
      description: auth-oauth2-oauth0-authorization-code-grant
      title: auth-oauth2-oauth0-authorization-code-grant
      version: 0.1.0
    openapi: 3.0.0
    paths:
      /:
        get:
          description: Returns GET data.
          operationId: /get
          responses: {}
      /uuid:
        get:
          description: Returns UUID4.
          operationId: /uuid
          responses: {}
    schemes:
    - http
    - https
    x-kusk:
      auth:
        oauth2:
          auth_scopes:
          - openid
          authorization_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/authorize
          credentials:
            client_id: upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8
            client_secret: Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ
          forward_bearer_token: true
          redirect_path_matcher: /oauth2/callback
          redirect_uri: /oauth2/callback
          signout_path: /oauth2/signout
          token_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/oauth/token
        scheme: oauth2
      upstream:
        service:
          name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
          namespace: default
          port: 80
    
```