### PR TITLE
Fixed rate_Limit example in docs

### DIFF
--- a/docs/docs/extension.md
+++ b/docs/docs/extension.md
@@ -286,7 +286,7 @@ Note: Currently, rate limiting is applied per Envoy pod - if you have more than 
 ...
 x-kusk:
   rate_limit:
-    requests_per_limit: 2
+    requests_per_unit: 2
     unit: minute
 ...
 ```


### PR DESCRIPTION
The rate_limit example had invalid syntax.

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
