### PR TITLE
Add correct `Content-Type` on mock results - #719

### DIFF
--- a/internal/mocking/routebuilder.go
+++ b/internal/mocking/routebuilder.go
@@ -66,7 +66,10 @@ type MockedRouteBuilder interface {
 // - text/plain
 // if the mediaType is not supported, an error is returned
 func NewRouteBuilder(mediaType string, rt *route.Route) (MockedRouteBuilder, error) {
-	baseMockedRouteBuilder := &baseMockedRouteBuilder{rt}
+	baseMockedRouteBuilder := &baseMockedRouteBuilder{
+		rt:        rt,
+		mediaType: mediaType,
+	}
 
 	switch {
 	case jsonMediaTypePattern.MatchString(mediaType):
@@ -87,7 +90,8 @@ func NewRouteBuilder(mediaType string, rt *route.Route) (MockedRouteBuilder, err
 }
 
 type baseMockedRouteBuilder struct {
-	rt *route.Route
+	rt        *route.Route
+	mediaType string
 }
 
 func (b *baseMockedRouteBuilder) getRoute(
@@ -120,6 +124,12 @@ func (b *baseMockedRouteBuilder) getRoute(
 					},
 					Append: &wrapperspb.BoolValue{
 						Value: true,
+					},
+				},
+				{
+					Header: &envoy_config_core_v3.HeaderValue{
+						Key:   "content-type",
+						Value: b.mediaType,
 					},
 				},
 			}...),

--- a/smoketests/mocking/mocking_test.go
+++ b/smoketests/mocking/mocking_test.go
@@ -45,6 +45,11 @@ func (m *MockCheckSuite) SetupTest() {
 }
 
 func (m *MockCheckSuite) TestEndpoint() {
+	const (
+		ContentTypeKey      = "content-type"
+		expectedContentType = "application/json"
+	)
+
 	envoyFleetSvc := &corev1.Service{}
 	m.NoError(
 		m.Cli.Get(context.TODO(), client.ObjectKey{Name: defaultName, Namespace: defaultNamespace}, envoyFleetSvc),
@@ -56,12 +61,15 @@ func (m *MockCheckSuite) TestEndpoint() {
 
 	m.Equal(200, resp.StatusCode)
 
+	actualContentType := resp.Header.Get(ContentTypeKey)
+	m.T().Logf("%s=%v", ContentTypeKey, actualContentType)
+	m.Equal(expectedContentType, actualContentType)
+
 	o, _ := io.ReadAll(resp.Body)
 	res := map[string]string{}
 	m.NoError(json.Unmarshal(o, &res))
 
 	m.Equal("Hello from a mocked response!", res["message"])
-
 }
 
 func (m *MockCheckSuite) TearDownTest() {


### PR DESCRIPTION
See: <https://github.com/kubeshop/kusk-gateway/issues/719>.

Fixes kubeshop/kusk-gateway#719.

`internal/mocking/routebuilder.go`
----------------------------------

Store `mediaType` in `baseMockedRouteBuilder` in `NewRouteBuilder`, and then use this later to add a `content-type` header to the `ResponseHeadersToAdd`.

`smoketests/mocking/mocking_test.go`
------------------------------------

Add assertion that checks that the response's `content-type` is `application/json`.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

```sh
$ cat mocking.yaml
---
apiVersion: gateway.kusk.io/v1alpha1
kind: API
metadata:
  name: test-mocking-api
  namespace: default
spec:
  fleet:
    name: default
    namespace: default
  spec: |
    openapi: 3.0.0
    info:
      title: test-mocking-api
      description: test-mocking-api
      version: "0.1.0"
    x-kusk:
      mocking:
        enabled: true
    paths:
      /hello:
        get:
          description: Returns Hello {name}.
          responses:
            200:
              description: Return a hello world message
              content:
                application/json:
                  schema:
                    type: object
                    properties:
                      message:
                        type: string
                  example:
                    message: Mocked Response!
$ kubectl apply -f mocking.yaml
$ curl -v 192.168.49.2/hello
*   Trying 192.168.49.2:80...
* Connected to 192.168.49.2 (192.168.49.2) port 80 (#0)
> GET /hello HTTP/1.1
> Host: 192.168.49.2
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-kusk-mocked: true
< content-type: application/json
< content-length: 30
< date: Mon, 12 Sep 2022 14:51:48 GMT
< server: envoy
< 
* Connection #0 to host 192.168.49.2 left intact
{"message":"Mocked Response!"}%
```

```sh
$ kubectl port-forward --namespace default deployment/default 19000:19000 &
$ curl -s 'http://localhost:19000/config_dump?include_eds' | jq '.configs[5].dynamic_route_configs[0]'
{
  "version_info": "d6486583-32a9-11ed-9696-0242ac110004",
  "route_config": {
    "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
    "name": "local_route",
    "virtual_hosts": [
      {
        "name": "*",
        "domains": [
          "*"
        ],
        "routes": [
          {
            "match": {
              "headers": [
                {
                  "name": ":method",
                  "string_match": {
                    "exact": "GET"
                  }
                }
              ],
              "safe_regex": {
                "google_re2": {},
                "regex": "/hello"
              }
            },
            "direct_response": {
              "status": 200,
              "body": {
                "inline_string": "{\"message\":\"Mocked Response!\"}"
              }
            },
            "response_headers_to_add": [
              {
                "header": {
                  "key": "x-kusk-mocked",
                  "value": "true"
                },
                "append": true
              },
              {
                "header": {
                  "key": "content-type",
                  "value": "application/json"
                }
              }
            ],
            "typed_per_filter_config": {
              "envoy.filters.http.ext_proc": {
                "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute",
                "disabled": true
              },
              "envoy.filters.http.ext_authz": {
                "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                "disabled": true
              }
            },
            "name": "/hello-GET-200-json"
          }
        ]
      }
    ]
  },
  "last_updated": "2022-09-12T14:47:34.430Z"
}
```