### PR TITLE
Introduce `verbosity` flag to `cmd/kusk`

### DIFF
--- a/cmd/kusk/apispec.yaml
+++ b/cmd/kusk/apispec.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: auth-oauth2-oauth0-authorization-code-grant
+  description: auth-oauth2-oauth0-authorization-code-grant
+  version: "0.1.0"
+schemes:
+  - http
+  - https
+x-kusk:
+  upstream:
+    service:
+      name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+      namespace: default
+      port: 80
+  auth:
+    scheme: oauth2
+    oauth2:
+      token_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/oauth/token
+      authorization_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/authorize
+      credentials:
+        client_id: upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8
+        client_secret: Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ
+      redirect_uri: /oauth2/callback
+      redirect_path_matcher: /oauth2/callback
+      signout_path: /oauth2/signout
+      forward_bearer_token: true
+      auth_scopes:
+        - openid
+paths:
+  "/":
+    get:
+      description: Returns GET data.
+      operationId: "/get"
+      responses: {}
+  "/uuid":
+    get:
+      description: Returns UUID4.
+      operationId: "/uuid"
+      responses: {}

--- a/cmd/kusk/cmd/install.go
+++ b/cmd/kusk/cmd/install.go
@@ -253,9 +253,9 @@ func updateHelmRepos(helmPath string) error {
 	if isLevelDebug() {
 		commandExecuted := helmPath + " " + strings.Join(commandArguments, " ")
 		if err != nil {
-			pterm.Info.Printf("%v output:\n%v\n", commandExecuted, string(out))
-		} else {
 			pterm.Info.Printf("%v output:\n%v\n%v error: \n%v\n", commandExecuted, string(out), commandExecuted, err)
+		} else {
+			pterm.Info.Printf("%v output:\n%v\n", commandExecuted, string(out))
 		}
 	}
 	return err

--- a/cmd/kusk/cmd/install.go
+++ b/cmd/kusk/cmd/install.go
@@ -251,7 +251,12 @@ func updateHelmRepos(helmPath string) error {
 	commandArguments := getHelmCommandArguments("repo", "update")
 	out, err := process.Execute(helmPath, commandArguments...)
 	if isLevelDebug() {
-		pterm.Info.Printf("%v output:\n%v\n", helmPath+" "+strings.Join(commandArguments, " "), string(out))
+		commandExecuted := helmPath + " " + strings.Join(commandArguments, " ")
+		if err != nil {
+			pterm.Info.Printf("%v output:\n%v\n", commandExecuted, string(out))
+		} else {
+			pterm.Info.Printf("%v output:\n%v\n%v error: \n%v\n", commandExecuted, string(out), commandExecuted, err)
+		}
 	}
 	return err
 }

--- a/cmd/kusk/cmd/root.go
+++ b/cmd/kusk/cmd/root.go
@@ -171,9 +171,8 @@ func getHelmCommandArguments(arguments ...string) []string {
 	commandArguments := []string{}
 	if isLevelDebug() {
 		commandArguments = append([]string{"--debug"}, arguments...)
-		return commandArguments
 	} else {
 		commandArguments = append(commandArguments, arguments...)
-		return commandArguments
 	}
+	return commandArguments
 }

--- a/cmd/kusk/cmd/root.go
+++ b/cmd/kusk/cmd/root.go
@@ -49,13 +49,18 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "kusk",
-	Short: "",
-	Long:  ``,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	Use:           "kusk",
+	Short:         "",
+	Long:          ``,
+	SilenceErrors: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		analytics.SendAnonymousCMDInfo(nil)
-		if cmd.Name() != generateCmd.Name() {
 
+		if !(verbosityLevel <= 4) {
+			return fmt.Errorf("verbosity must be between 0 and 4 (inclusive), verbosity level = %v", verbosityLevel)
+		}
+
+		if cmd.Name() != generateCmd.Name() {
 			if len(build.Version) != 0 {
 				ghclient, _ := utils.NewGithubClient("", nil)
 				i, _, err := ghclient.GetTags()
@@ -83,6 +88,8 @@ var rootCmd = &cobra.Command{
 				}
 			}
 		}
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
Verbosity is a number for the log level verbosity, 0 is the lowest and results in the lowest amount of information being printed.

Example:

```sh
$ kusk --help
Usage:
  kusk [command]

Available Commands:
  cluster     parent command for cluster related functions
  completion  Generate the autocompletion script for the specified shell
  dashboard   Access the kusk dashboard
  deploy      deploy command to deploy your apis
  generate    Generate a Kusk Gateway API resource from your OpenAPI spec file
  help        Help about any command
  ip          return IP address of the default envoyfleet
  mock        Spin up a local mocking server serving your API
  version     version for kusk

Flags:
      --config string      config file (default is $HOME/.kusk.yaml)
  -h, --help               help for kusk
  -t, --toggle             Help message for toggle
  -v, --verbosity uint32   number for the log level verbosity, 0=error, 1=warn, 2=info, 3=debug and 4=trace.
      --version            version for kusk

Use "kusk [command] --help" for more information about a command.
```

`cmd/kusk/cmd/root.go`
----------------------

This uses the `HELM_DEBUG` environmental variable to enable debugging instead of having to append `--debug` to every helm command.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

## Example Output

https://gist.github.com/mbana/42562ee6eb552ac2266246c47a7bcc67