### PR TITLE
`make create-env`: should work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,11 @@ run: $(KTUNNEL) install-local generate fmt vet ## Run a controller from your hos
 
 .PHONY: docker-build-manager
 docker-build-manager: ## Build docker image with the manager.
-	eval $$(minikube docker-env --profile kgw); docker build -t ${MANAGER_IMG} -f ./build/manager/Dockerfile .
+	eval $$(minikube docker-env --profile kgw); docker build \
+		--tag ${MANAGER_IMG} \
+		--tag kusk-gateway:latest \
+		--file ./build/manager/Dockerfile \
+		.
 
 .PHONY: docker-build
 docker-build: docker-build-manager ## Build docker images for all apps

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,6 +26,7 @@ spec:
         - command:
             - /manager
           image: kusk-gateway:latest
+          imagePullPolicy: IfNotPresent
           name: manager
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

More information: `imagePullPolicy: IfNotPresent` not pulling images with latest tag - https://github.com/kubernetes/kubernetes/issues/47775

---

Could you please give this a trial run. I ran against

```sh
$ minikube version  
minikube version: v1.26.1
commit: 62e108c3dfdec8029a890ad6d8ef96b6461426dc
```

```sh
$ make check-all
make check-all
make -C smoketests check-mocking
make[1]: Entering directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
Makefile:8: warning: overriding recipe for target 'check-basic_auth'
Makefile:4: warning: ignoring old recipe for target 'check-basic_auth'
Makefile:16: warning: overriding recipe for target 'check-cache'
Makefile:4: warning: ignoring old recipe for target 'check-cache'
Makefile:21: warning: overriding recipe for target 'check-openapi-path'
Makefile:4: warning: ignoring old recipe for target 'check-openapi-path'
Makefile:27: warning: overriding recipe for target 'check-auth_oauth2'
Makefile:4: warning: ignoring old recipe for target 'check-auth_oauth2'
go mod tidy
go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/mocking
=== RUN   TestMockingSuite
=== RUN   TestMockingSuite/TestEndpoint
    mocking_test.go:65: content-type=application/json
--- PASS: TestMockingSuite (6.03s)
    --- PASS: TestMockingSuite/TestEndpoint (3.02s)
PASS
ok  	github.com/kubeshop/kusk-gateway/smoketests/mocking	6.045s
make[1]: Leaving directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
make -C smoketests check-basic
make[1]: Entering directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
Makefile:8: warning: overriding recipe for target 'check-basic_auth'
Makefile:4: warning: ignoring old recipe for target 'check-basic_auth'
Makefile:16: warning: overriding recipe for target 'check-cache'
Makefile:4: warning: ignoring old recipe for target 'check-cache'
Makefile:21: warning: overriding recipe for target 'check-openapi-path'
Makefile:4: warning: ignoring old recipe for target 'check-openapi-path'
Makefile:27: warning: overriding recipe for target 'check-auth_oauth2'
Makefile:4: warning: ignoring old recipe for target 'check-auth_oauth2'
go mod tidy
go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/basic
=== RUN   TestBasichCheckSuite
=== RUN   TestBasichCheckSuite/TestGetAPI
=== RUN   TestBasichCheckSuite/TestGetFleet
--- PASS: TestBasichCheckSuite (3.06s)
    --- PASS: TestBasichCheckSuite/TestGetAPI (0.03s)
    --- PASS: TestBasichCheckSuite/TestGetFleet (0.02s)
PASS
ok  	github.com/kubeshop/kusk-gateway/smoketests/basic	3.080s
make[1]: Leaving directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
make -C smoketests check-cache
make[1]: Entering directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
Makefile:8: warning: overriding recipe for target 'check-basic_auth'
Makefile:4: warning: ignoring old recipe for target 'check-basic_auth'
Makefile:16: warning: overriding recipe for target 'check-cache'
Makefile:4: warning: ignoring old recipe for target 'check-cache'
Makefile:21: warning: overriding recipe for target 'check-openapi-path'
Makefile:4: warning: ignoring old recipe for target 'check-openapi-path'
Makefile:27: warning: overriding recipe for target 'check-auth_oauth2'
Makefile:4: warning: ignoring old recipe for target 'check-auth_oauth2'
kubectl apply -f ./samples/cache/cache-upstream.yaml
deployment.apps/httpbin unchanged
service/httpbin unchanged
go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/cache
=== RUN   TestCacheTestSuite
=== RUN   TestCacheTestSuite/TestCacheCacheOn
    cache_test.go:76: Sleeping for 8s
--- PASS: TestCacheTestSuite (14.03s)
    --- PASS: TestCacheTestSuite/TestCacheCacheOn (11.02s)
PASS
ok  	github.com/kubeshop/kusk-gateway/smoketests/cache	14.046s
kubectl delete -f ./samples/cache/cache-upstream.yaml
deployment.apps "httpbin" deleted
service "httpbin" deleted
make[1]: Leaving directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
make -C smoketests check-rate_limit
make[1]: Entering directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
Makefile:8: warning: overriding recipe for target 'check-basic_auth'
Makefile:4: warning: ignoring old recipe for target 'check-basic_auth'
Makefile:16: warning: overriding recipe for target 'check-cache'
Makefile:4: warning: ignoring old recipe for target 'check-cache'
Makefile:21: warning: overriding recipe for target 'check-openapi-path'
Makefile:4: warning: ignoring old recipe for target 'check-openapi-path'
Makefile:27: warning: overriding recipe for target 'check-auth_oauth2'
Makefile:4: warning: ignoring old recipe for target 'check-auth_oauth2'
go mod tidy
go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/rate_limit
=== RUN   TestRateLimitTestSuite
=== RUN   TestRateLimitTestSuite/TestRateLimitReached
--- PASS: TestRateLimitTestSuite (4.02s)
    --- PASS: TestRateLimitTestSuite/TestRateLimitReached (1.01s)
PASS
ok  	github.com/kubeshop/kusk-gateway/smoketests/rate_limit	4.040s
make[1]: Leaving directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
make -C smoketests check-basic_auth
make[1]: Entering directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
Makefile:8: warning: overriding recipe for target 'check-basic_auth'
Makefile:4: warning: ignoring old recipe for target 'check-basic_auth'
Makefile:16: warning: overriding recipe for target 'check-cache'
Makefile:4: warning: ignoring old recipe for target 'check-cache'
Makefile:21: warning: overriding recipe for target 'check-openapi-path'
Makefile:4: warning: ignoring old recipe for target 'check-openapi-path'
Makefile:27: warning: overriding recipe for target 'check-auth_oauth2'
Makefile:4: warning: ignoring old recipe for target 'check-auth_oauth2'
kubectl apply -f ../examples/ext-authz/http-basic-auth/
api.gateway.kusk.io/ext-authz-http-basic-auth created
deployment.apps/ext-authz-http-basic-auth created
service/ext-authz-http-basic-auth created
deployment.apps/ext-authz-httpbin created
service/ext-authz-httpbin created
kubectl wait --namespace default deployment ext-authz-http-basic-auth --for condition=Available=True --timeout=3m
deployment.apps/ext-authz-http-basic-auth condition met
sleeping for 6s ...
go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/basic_auth
=== RUN   TestBasicAuthCheckSuite
=== RUN   TestBasicAuthCheckSuite/TestAuthorized
    basic_auth_test.go:76: sleeping for 20s
=== RUN   TestBasicAuthCheckSuite/TestUnauthorized
    basic_auth_test.go:66: apis.gateway.kusk.io "auth-test" already exists
=== RUN   TestBasicAuthCheckSuite/TestUnauthorizedNoCredentials
    basic_auth_test.go:66: apis.gateway.kusk.io "auth-test" already exists
--- PASS: TestBasicAuthCheckSuite (23.05s)
    --- PASS: TestBasicAuthCheckSuite/TestAuthorized (20.01s)
    --- PASS: TestBasicAuthCheckSuite/TestUnauthorized (0.01s)
    --- PASS: TestBasicAuthCheckSuite/TestUnauthorizedNoCredentials (0.01s)
PASS
ok  	github.com/kubeshop/kusk-gateway/smoketests/basic_auth	23.065s
kubectl delete -f ../examples/ext-authz/http-basic-auth/
api.gateway.kusk.io "ext-authz-http-basic-auth" deleted
deployment.apps "ext-authz-http-basic-auth" deleted
service "ext-authz-http-basic-auth" deleted
deployment.apps "ext-authz-httpbin" deleted
service "ext-authz-httpbin" deleted
make[1]: Leaving directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
make -C smoketests check-auth_oauth2
make[1]: Entering directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
Makefile:8: warning: overriding recipe for target 'check-basic_auth'
Makefile:4: warning: ignoring old recipe for target 'check-basic_auth'
Makefile:16: warning: overriding recipe for target 'check-cache'
Makefile:4: warning: ignoring old recipe for target 'check-cache'
Makefile:21: warning: overriding recipe for target 'check-openapi-path'
Makefile:4: warning: ignoring old recipe for target 'check-openapi-path'
Makefile:27: warning: overriding recipe for target 'check-auth_oauth2'
Makefile:4: warning: ignoring old recipe for target 'check-auth_oauth2'
kubectl apply -f ../examples/auth/oauth2/authorization-code-grant/manifests.yaml
deployment.apps/auth-oauth2-oauth0-authorization-code-grant-go-httpbin created
service/auth-oauth2-oauth0-authorization-code-grant-go-httpbin created
kubectl wait deployment --namespace default auth-oauth2-oauth0-authorization-code-grant-go-httpbin --for condition=Available=True --timeout=3m
deployment.apps/auth-oauth2-oauth0-authorization-code-grant-go-httpbin condition met
go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/auth_oauth2
=== RUN   TestAuthOAuth2TestSuite
=== RUN   TestAuthOAuth2TestSuite/TestRootPathReturnsARedirect
    auth_oauth2_test.go:87: Sleeping for 5s
=== RUN   TestAuthOAuth2TestSuite/TestUUIDPathReturnsARedirect
--- PASS: TestAuthOAuth2TestSuite (8.04s)
    --- PASS: TestAuthOAuth2TestSuite/TestRootPathReturnsARedirect (5.01s)
    --- PASS: TestAuthOAuth2TestSuite/TestUUIDPathReturnsARedirect (0.01s)
PASS
ok  	github.com/kubeshop/kusk-gateway/smoketests/auth_oauth2	8.055s
kubectl delete -f ../examples/auth/oauth2/authorization-code-grant/manifests.yaml
deployment.apps "auth-oauth2-oauth0-authorization-code-grant-go-httpbin" deleted
service "auth-oauth2-oauth0-authorization-code-grant-go-httpbin" deleted
make[1]: Leaving directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
make -C smoketests check-openapi-path
make[1]: Entering directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
Makefile:8: warning: overriding recipe for target 'check-basic_auth'
Makefile:4: warning: ignoring old recipe for target 'check-basic_auth'
Makefile:16: warning: overriding recipe for target 'check-cache'
Makefile:4: warning: ignoring old recipe for target 'check-cache'
Makefile:21: warning: overriding recipe for target 'check-openapi-path'
Makefile:4: warning: ignoring old recipe for target 'check-openapi-path'
Makefile:27: warning: overriding recipe for target 'check-auth_oauth2'
Makefile:4: warning: ignoring old recipe for target 'check-auth_oauth2'
kubectl apply -f ./samples/openapi-path/openapi-path-with-auth-upstream.yaml
deployment.apps/ext-authz-http-basic-auth-openapi-path-with-auth created
service/ext-authz-http-basic-auth-openapi-path-with-auth created
deployment.apps/httpbin created
service/httpbin created
kubectl wait deployment ext-authz-http-basic-auth-openapi-path-with-auth --namespace=default --for condition=Available=True --timeout=3m
deployment.apps/ext-authz-http-basic-auth-openapi-path-with-auth condition met
go test -count=1 -v github.com/kubeshop/kusk-gateway/smoketests/openapi-path
=== RUN   TestOpenAPIPathTestSuite
=== RUN   TestOpenAPIPathTestSuite/TestOpenAPIPathWithAuthOK
    openapi-path_test.go:75: Sleeping for 5s
=== RUN   TestOpenAPIPathTestSuite/TestOpenAPIPathWithAuthUnauthorized
--- PASS: TestOpenAPIPathTestSuite (8.04s)
    --- PASS: TestOpenAPIPathTestSuite/TestOpenAPIPathWithAuthOK (5.01s)
    --- PASS: TestOpenAPIPathTestSuite/TestOpenAPIPathWithAuthUnauthorized (0.01s)
PASS
ok  	github.com/kubeshop/kusk-gateway/smoketests/openapi-path	8.054s
kubectl delete -f ./samples/openapi-path/openapi-path-with-auth-upstream.yaml
deployment.apps "ext-authz-http-basic-auth-openapi-path-with-auth" deleted
service "ext-authz-http-basic-auth-openapi-path-with-auth" deleted
deployment.apps "httpbin" deleted
service "httpbin" deleted
make[1]: Leaving directory '/home/mbana/work/kubeshop.io/kusk-gateway/smoketests'
```

and it failed once but passed on the other occasion.
