### PR TITLE
Cleanup `cmd/kusk/Makefile` and `Makefile`, and ensure `cmd/kusk` is built in GitHub Workflow

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,10 +26,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
-      - name:
-        run: make test
+          go-version: 1.19
+      - name: build-cli
         working-directory: cmd/kusk
+        run: VERSION=${{ github.sha }} make build
+      - name: test-cli
+        working-directory: cmd/kusk
+        run: make test
   compilation-and-unit-test-manager:
     name: Compile and Test Manager
     runs-on: ubuntu-latest
@@ -166,5 +169,5 @@ jobs:
           helm delete  kusk-gateway-envoyfleet-pr-${{ github.event.pull_request.number }} \
             --namespace default
           helm delete kusk-gateway-pr-${{ github.event.pull_request.number }} \
-            --namespace kusk-gateway-pr-${{ github.event.pull_request.number }} 
+            --namespace kusk-gateway-pr-${{ github.event.pull_request.number }}
           kubectl delete ns kusk-gateway-pr-${{ github.event.pull_request.number }}

--- a/cmd/kusk/Makefile
+++ b/cmd/kusk/Makefile
@@ -1,9 +1,6 @@
 .DEFAULT_GOAL := all
 MAKEFLAGS += --environment-overrides --warn-undefined-variables #--print-directory --no-builtin-rules --no-builtin-variables
 
-
-
-
 SHELL := /bin/bash
 ifneq ($(shell uname),Darwin)
 	SHELL += -O globstar -O extglob
@@ -16,42 +13,22 @@ export PATH := $(shell go env GOPATH)/bin:${PATH}
 
 VERSION ?= $(shell git describe --tags)
 
-
-MAKE_PATH := $(shell pwd)
-MAKE_DIR := $(shell dirname $(MAKE_PATH))
-
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
-KUSTOMIZE_VERSION ?= v4.5.2
-
-LOCALBIN ?= $(shell pwd)/bin
-KUSTOMIZE = $(LOCALBIN)/kustomize
-CONTROLLER_GEN = $(LOCALBIN)/controller-gen
-
 LD_FLAGS += -w -s
 LD_FLAGS += -X 'github.com/kubeshop/kusk-gateway/pkg/build.Version=${VERSION}'
-LD_FLAGS += -X 'github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$(TELEMETRY_TOKEN)'
+LD_FLAGS += -X 'github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=${TELEMETRY_TOKEN}'
 
 IMAGE_TAG ?= ${VERSION}
 MANAGER_IMG ?= kubeshop/kusk-gateway:${IMAGE_TAG}
-# Determine if we should use:
-# 1. docker and docker-compose, or
-# 2. podman and podman-compose
+
+# Determine if we should use: docker or podman.
 CONTAINER_ENGINE ?= $(shell docker version >/dev/null 2>&1 && which docker)
 ifeq ($(CONTAINER_ENGINE),)
 	CONTAINER_ENGINE = $(shell podman version >/dev/null 2>&1 && which podman)
 endif
 
-
 .PHONY: all
-all: install-tools pre-commit
+all: install-tools install-deps pre-commit
 
-build-tools: ## $(KUSTOMIZE) ## Download kustomize locally if necessary.
-# $(KUSTOMIZE): $(LOCALBIN)
-	mkdir -p $(shell pwd)/bin
-	rm -f $(KUSTOMIZE)
-	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
-	GOBIN=$(shell pwd)/bin go install -a -v github.com/go-bindata/go-bindata/...@latest
-	
 .PHONY: install-tools
 install-tools:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
@@ -79,10 +56,15 @@ lint:
 test:
 	go test -count=1 -v -race ./...
 
+.PHONY: install-deps
+install-deps:
+	go install github.com/go-bindata/go-bindata/v3/go-bindata@v3.1.3
+	go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.2
+
 .PHONY: build
-build: build-tools
-	cd ../../config/default && $(KUSTOMIZE) edit set image kusk-gateway=${MANAGER_IMG}
-	go generate 
+build: install-deps
+	cd ../../config/default && kustomize edit set image kusk-gateway=${MANAGER_IMG}
+	go generate
 	go build -v -o ./kusk -ldflags="${LD_FLAGS}" ./main.go
 
 # `build-goreleaser` is just for local testing.

--- a/cmd/kusk/main.go
+++ b/cmd/kusk/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kubeshop/kusk-gateway/cmd/kusk/cmd"
 )
 
-//go:generate bin/go-bindata -prefix "../../" -o cmd/manifest_data.go -pkg=cmd -ignore=debug/ -ignore=local/ -ignore=prometheus/ -ignore=samples/ ../../config/... manifests/...
+//go:generate go-bindata -prefix "../../" -o cmd/manifest_data.go -pkg=cmd -ignore=debug/ -ignore=local/ -ignore=prometheus/ -ignore=samples/ ../../config/... manifests/...
 func main() {
 	cmd.Execute()
 }


### PR DESCRIPTION
`cmd/kusk/Makefile` and `Makefile`
----------------------------------

Use `go install` for installing all the dependencies instead of installing them to the `bin/` folder.

`.github/workflows/pull-request.yaml`
-------------------------------------

Ensure `cmd/kusk` is built.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

Improve developer workflow.

I've also added `test-cli` step in the GitHub Workflow to ensure the `kusk` builds using `... make build ...`

---

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
