### PR TITLE
`.github/workflows/release.yaml`: Use go `1.19`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -80,7 +80,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           build-args: |
             TELEMETRY_TOKEN=${{ secrets.TELEMETRY_TOKEN }}
-            TELEMETRY_TOKEN=${{ secrets.TELEMETRY_TOKEN }}
+
       - name: Update docker cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: setup-golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub


### PR DESCRIPTION
Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

```sh
wget https://go.dev/dl/go1.17.linux-amd64.tar.gz                                                                                                                  
mkdir -pv ~/.local
tar -C ~/.local -xzf go1.17.linux-amd64.tar.gz
export PATH="~/.local/go/bin:${PATH}" 
$ TELEMETRY_TOKEN="" VERSION="v1.3.0" goreleaser release --rm-dist --skip-publish --skip-validate
   • releasing...     
   • could not find a config file, using defaults...
   • loading environment variables
   • getting and validating git state
   ⨯ release failed after 0.00s error=current folder is not a git repository
➜  /tmp work-dir
➜  kusk-gateway git:(main) ✗ TELEMETRY_TOKEN="" VERSION="v1.3.0" goreleaser release --rm-dist --skip-publish --skip-validate
   • releasing...     
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=b23da400311117f2428dd7a2cfc618315dffa74d latest tag=v1.3.0
      • pipe skipped              error=validation is disabled
   • parsing tag      
   • running before hooks
      • running                   hook=go mod tidy
   ⨯ release failed after 0.03s error=hook failed: go mod tidy: exit status 1; output: go mod tidy: go.mod file indicates go 1.18, but maximum supported version is 1.17
```


---


This PR...

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
