### PR TITLE
Fix `.github/workflows/release.yaml`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,17 +22,36 @@ jobs:
     name: Compile and Test Kusk CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout
+        uses: actions/checkout@v2
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.19
+
+      - name: setup-environment-variables
+        run: |
+          go version
+          echo "VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
+
       - name: build-cli
         working-directory: cmd/kusk
-        run: VERSION=${{ github.sha }} make build
+        run: |
+          go version
+          VERSION=${{ github.sha }} make build
+
       - name: test-cli
         working-directory: cmd/kusk
-        run: make test
+        run: |
+          go version
+          make test
+
+      - name: prepare-cli-manifests # this step will ensure that kusk kustomize manifests are build with the latest image tag github.sha
+        working-directory: cmd/kusk
+        run: |
+          go version
+          VERSION=${{ env.VERSION }} make manifests
 
   compilation-and-unit-test-manager:
     name: Compile and Test Manager

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,12 +77,17 @@ jobs:
             TELEMETRY_TOKEN=${{ secrets.TELEMETRY_TOKEN }}
             VERSION=${{ env.VERSION }}
 
-      - name: prepare-cli-manifests # this step will ensure that kusk kustomize manifests are build with the latest image tag github.sha
+      # Possibly not needed. Please remove, if it turns out go has already been setup.
+      - name: setup-golang
         uses: actions/setup-go@v2
         with:
           go-version: 1.19
+
+      - name: prepare-cli-manifests # this step will ensure that kusk kustomize manifests are build with the latest image tag github.sha
         working-directory: cmd/kusk
-        run: VERSION=${{ env.VERSION }} make manifests
+        run: |
+          go version
+          VERSION=${{ env.VERSION }} make manifests
 
       - name: Run GoReleaser to publish release notes
         uses: goreleaser/goreleaser-action@v2

--- a/cmd/kusk/main.go
+++ b/cmd/kusk/main.go
@@ -1,26 +1,25 @@
-/*
-The MIT License (MIT)
+// MIT License
+//
+// Copyright (c) 2022 Kubeshop
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
-Copyright © 2022 Kubeshop
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
 package main
 
 import (


### PR DESCRIPTION
`.github/workflows/release.yaml`
--------------------------------

> a step cannot have both the `uses` and `run` keys

See: https://github.com/kubeshop/kusk-gateway/actions/runs/3190983088

`.github/workflows/pull-request.yaml`
-------------------------------------

The change to this file should be reverted if the commit to `main` passes.

Signed-off-by: Mohamed Bana <mohamed@bana.io>
