### PR TITLE
Disable OAuth2 on the root path

### DIFF
--- a/examples/auth/oauth2/authorization-code-grant-root-disabled/Makefile
+++ b/examples/auth/oauth2/authorization-code-grant-root-disabled/Makefile
@@ -1,0 +1,6 @@
+.PHONY: recreate-api
+recreate-api:
+	-kubectl delete -f ./api.yaml
+	-kubectl delete -f ./manifests.yaml
+	-kubectl apply -f ./api.yaml
+	-kubectl apply -f ./manifests.yaml

--- a/examples/auth/oauth2/authorization-code-grant-root-disabled/api.yaml
+++ b/examples/auth/oauth2/authorization-code-grant-root-disabled/api.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.kusk.io/v1alpha1
+kind: API
+metadata:
+  name: auth-oauth2-oauth0-authorization-code-grant-root-disabled
+  namespace: default
+spec:
+  fleet:
+    name: default
+    namespace: default
+  spec: |
+    openapi: 3.1.0
+    info:
+      title: auth-oauth2-oauth0-authorization-code-grant-root-disabled
+      description: auth-oauth2-oauth0-authorization-code-grant-root-disabled
+      version: '0.1.0'
+    schemes:
+    - http
+    - https
+    x-kusk:
+      upstream:
+        service:
+          name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+          namespace: default
+          port: 80
+      auth:
+        scheme: oauth2
+        oauth2:
+          token_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/oauth/token
+          authorization_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/authorize
+          credentials:
+            client_id: upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8
+            client_secret: Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ
+          redirect_uri: /oauth2/callback
+          redirect_path_matcher: /oauth2/callback
+          signout_path: /oauth2/signout
+          forward_bearer_token: true
+          auth_scopes:
+            - openid
+    paths:
+      "/":
+        get:
+          description: Returns GET data.
+          operationId: "/get"
+          responses: {}
+      "/uuid":
+        get:
+          description: Returns UUID4.
+          operationId: "/uuid"
+          responses: {}

--- a/examples/auth/oauth2/authorization-code-grant-root-disabled/manifests.yaml
+++ b/examples/auth/oauth2/authorization-code-grant-root-disabled/manifests.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+  namespace: default
+  labels:
+    app: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+spec:
+  selector:
+    matchLabels:
+      app: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+    spec:
+      containers:
+        - name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+          image: docker.io/mccutchen/go-httpbin:v2.4.1
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+  namespace: default
+  labels:
+    app: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+spec:
+  selector:
+    app: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/internal/envoy/auth/oauth2_filter.go
+++ b/internal/envoy/auth/oauth2_filter.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_extensions_filter_http_oauth2_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/oauth2/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 
@@ -110,6 +111,16 @@ func NewFilterHTTPOAuth2(oauth2Options *options.OAuth2, args *parseAuthOptionsAr
 	authScopes := oauth2Options.AuthScopes
 	resources := oauth2Options.Resources
 
+	// Disable OAuth2 on the root path - "/" - see: <https://github.com/kubeshop/kusk-gateway/issues/680>.
+	passThroughMatcher := []*envoy_config_route_v3.HeaderMatcher{
+		{
+			Name: ":path",
+			HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_ExactMatch{
+				ExactMatch: "/",
+			},
+		},
+	}
+
 	config := &envoy_extensions_filter_http_oauth2_v3.OAuth2Config{
 		// Endpoint on the authorization server to retrieve the access token from.
 		TokenEndpoint: tokenEndpoint,
@@ -129,8 +140,8 @@ func NewFilterHTTPOAuth2(oauth2Options *options.OAuth2, args *parseAuthOptionsAr
 		SignoutPath: signoutPath,
 		// Forward the OAuth token as a Bearer to upstream web service.
 		ForwardBearerToken: forwardBearerToken,
-		// // Any request that matches any of the provided matchers will be passed through without OAuth validation.
-		// PassThroughMatcher: nil,
+		// Any request that matches any of the provided matchers will be passed through without OAuth validation.
+		PassThroughMatcher: passThroughMatcher,
 		// Optional list of OAuth scopes to be claimed in the authorization request. If not specified,
 		// defaults to "user" scope.
 		// OAuth RFC https://tools.ietf.org/html/rfc6749#section-3.3

--- a/smoketests/auth_oauth2/auth_oauth2_test.go
+++ b/smoketests/auth_oauth2/auth_oauth2_test.go
@@ -114,9 +114,8 @@ func (t *AuthOAuth2TestSuite) TestUUIDPathReturnsARedirect() {
 	t.Contains(redirect.String(), redirectExpected)
 }
 
-func (t *AuthOAuth2TestSuite) TestRootPathReturnsARedirect() {
-	// Calling `/` should return the below:
-	redirectExpected := `https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/authorize?client_id=upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8&scope=openid&response_type=code`
+func (t *AuthOAuth2TestSuite) TestOAuth2IsDisabledOnRootPath() {
+	// Calling `/` should be fine even if OAuth2 is configured as the root path is un-protected.
 
 	envoyFleetSvc := getEnvoyFleetSvc(&t.KuskTestSuite)
 	url := fmt.Sprintf("http://%s/", envoyFleetSvc.Status.LoadBalancer.Ingress[0].IP)
@@ -127,15 +126,11 @@ func (t *AuthOAuth2TestSuite) TestRootPathReturnsARedirect() {
 	client := makeHTTPClient()
 	response, err := client.Do(request)
 	t.NoError(err)
-	t.Equal(http.StatusFound, response.StatusCode)
+	t.Equal(http.StatusOK, response.StatusCode)
 
 	defer func() {
 		t.NoError(response.Body.Close())
 	}()
-
-	redirect, err := response.Location()
-	t.NoError(err)
-	t.Contains(redirect.String(), redirectExpected)
 }
 
 func getEnvoyFleetSvc(t *common.KuskTestSuite) *corev1.Service {


### PR DESCRIPTION
Disable OAuth2 validation for the root path - `"/"` - by specifying a `pass_through_matcher` in `internal/envoy/auth/oauth2_filter.go`:

> `pass_through_matcher`
> (**repeated** `config.route.v3.HeaderMatcher`) Any request that matches any of the provided matchers will be passed through without OAuth validation.

Source: <https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/oauth2/v3/oauth.proto#extensions-filters-http-oauth2-v3-oauth2config>.

---

Resolves kubeshop/kusk-gateway/issues/680.

See: <https://github.com/kubeshop/kusk-gateway/issues/680>.

Signed-off-by: Mohamed Bana <mohamed@bana.io>