### PR TITLE
OAuth2: read `client_secret` from Kuberenets Secret

### DIFF
--- a/examples/auth/oauth2/client-secret-ref/Makefile
+++ b/examples/auth/oauth2/client-secret-ref/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all
+all:
+	-kubectl delete -f ./secret.yaml
+	-kubectl delete -f ./manifests.yaml
+	-kubectl delete -f ./api.yaml
+	-kubectl apply -f ./secret.yaml
+	-kubectl apply -f ./manifests.yaml
+	-kubectl apply -f ./api.yaml

--- a/examples/auth/oauth2/client-secret-ref/api.yaml
+++ b/examples/auth/oauth2/client-secret-ref/api.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.kusk.io/v1alpha1
 kind: API
 metadata:
-  name: auth-oauth2-oauth0-authorization-code-grant
+  name: auth-oauth2-oauth0-client-secret-ref
   namespace: default
 spec:
   fleet:
@@ -10,16 +10,16 @@ spec:
   spec: |
     openapi: 3.1.0
     info:
-      title: auth-oauth2-oauth0-authorization-code-grant
-      description: auth-oauth2-oauth0-authorization-code-grant
-      version: '0.1.0'
+      title: "auth-oauth2-oauth0-client-secret-ref"
+      description: "auth-oauth2-oauth0-client-secret-ref"
+      version: "0.1.0"
     schemes:
     - http
     - https
     x-kusk:
       upstream:
         service:
-          name: auth-oauth2-oauth0-authorization-code-grant-go-httpbin
+          name: auth-oauth2-oauth0-client-secret-ref-go-httpbin
           namespace: default
           port: 80
       auth:
@@ -28,8 +28,10 @@ spec:
           token_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/oauth/token
           authorization_endpoint: https://kubeshop-kusk-gateway-oauth2.eu.auth0.com/authorize
           credentials:
-            client_id: "upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8"
-            client_secret: "Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ"
+            client_id: upRN78W8GzV4TwFRp0ekZfLx2UnqJJs8
+            client_secret_ref:
+              name: "auth-oauth2-oauth0-client-secret-ref-api"
+              namespace: "oauth2-secrets"
           redirect_uri: /oauth2/callback
           redirect_path_matcher: /oauth2/callback
           signout_path: /oauth2/signout

--- a/examples/auth/oauth2/client-secret-ref/manifests.yaml
+++ b/examples/auth/oauth2/client-secret-ref/manifests.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+  namespace: default
+  labels:
+    app: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+spec:
+  selector:
+    matchLabels:
+      app: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+    spec:
+      containers:
+        - name: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+          image: docker.io/mccutchen/go-httpbin:v2.4.1
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+  namespace: default
+  labels:
+    app: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+spec:
+  selector:
+    app: auth-oauth2-oauth0-client-secret-ref-go-httpbin
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/examples/auth/oauth2/client-secret-ref/secret.yaml
+++ b/examples/auth/oauth2/client-secret-ref/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oauth2-secrets
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-oauth2-oauth0-client-secret-ref-api
+  namespace: oauth2-secrets
+type: Opaque
+data:
+  client_secret: "WjZNWDdOcmVKdW1XTG1mNnVuc1E1dWlFVXJUQnhmTnRxRzlWeTVLamt0bnZmai1fZlJDQk85RVUxbUwxWXpBSgo="

--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeshop/kusk-gateway/internal/cloudentity"
 	"github.com/kubeshop/kusk-gateway/internal/envoy/auth"
@@ -83,6 +84,7 @@ func UpdateConfigFromAPIOpts(
 	httpConnectionManagerBuilder *config.HCMBuilder,
 	clBuilder *cloudentity.Builder,
 	name string,
+	kubernetesClient client.Client,
 ) error {
 	logger := ctrl.Log.WithName("internal/controllers/parser.go:UpdateConfigFromAPIOpts")
 
@@ -160,6 +162,7 @@ func UpdateConfigFromAPIOpts(
 					method,
 					clBuilder,
 					generateClusterName, // each cluster can be uniquely identified by dns name + port (i.e. canonical Host, which is hostname:port)
+					kubernetesClient,
 				)
 
 				err := auth.ParseAuthOptions(finalOpts, arguments)

--- a/internal/envoy/auth/parser.go
+++ b/internal/envoy/auth/parser.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeshop/kusk-gateway/internal/cloudentity"
 	"github.com/kubeshop/kusk-gateway/internal/envoy/config"
@@ -48,6 +49,7 @@ type parseAuthOptionsArguments struct {
 	Method                       string
 	CloudEntityBuilder           *cloudentity.Builder
 	GenerateClusterName          generateClusterNameFunc
+	KubernetesClient             client.Client
 }
 
 func NewParseAuthOptionsArguments(
@@ -57,7 +59,9 @@ func NewParseAuthOptionsArguments(
 	name string, routePathstring,
 	method string,
 	cloudEntityBuilder *cloudentity.Builder,
-	generateClusterName generateClusterNameFunc) *parseAuthOptionsArguments {
+	generateClusterName generateClusterNameFunc,
+	kubernetesClient client.Client,
+) *parseAuthOptionsArguments {
 	return &parseAuthOptionsArguments{
 		Logger:                       logger,
 		EnvoyConfiguration:           envoyConfiguration,
@@ -67,6 +71,7 @@ func NewParseAuthOptionsArguments(
 		Method:                       method,
 		CloudEntityBuilder:           cloudEntityBuilder,
 		GenerateClusterName:          generateClusterName,
+		KubernetesClient:             kubernetesClient,
 	}
 }
 

--- a/pkg/options/auth_test.go
+++ b/pkg/options/auth_test.go
@@ -40,7 +40,6 @@ func Test_AuthOptions_UnmarshalStrict(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			// name: "basic-auth",
 			input: `
 auth:
   scheme: basic
@@ -62,7 +61,6 @@ auth:
 			},
 		},
 		{
-			// name: "oauth2",
 			input: `
 auth:
   scheme: oauth2
@@ -70,10 +68,9 @@ auth:
     token_endpoint: https://oauth2.googleapis.com/token
     authorization_endpoint: https://accounts.google.com/o/oauth2/auth
     credentials:
-      client_id: client_id
-      client_secret: client_secret
-      token_secret: token_secret
-      hmac_secret: hmac_secret
+      client_id: "client_id"
+      client_secret: "client_secret"
+      hmac_secret: "hmac_secret"
     redirect_uri: http://localhost
     redirect_path_matcher: /oauth2/callback
     signout_path: /oauth2/signout
@@ -92,9 +89,59 @@ auth:
 					AuthorizationEndpoint: "https://accounts.google.com/o/oauth2/auth",
 					Credentials: Credentials{
 						ClientID:     "client_id",
-						ClientSecret: "client_secret",
-						TokenSecret:  "token_secret",
+						ClientSecret: StringToPtr("client_secret"),
 						HmacSecret:   "hmac_secret",
+						CookieNames: CookieNames{
+							BearerToken:  "",
+							OauthHMAC:    "",
+							ExpiresOauth: "",
+						},
+					},
+					RedirectURI:         "http://localhost",
+					RedirectPathMatcher: "/oauth2/callback",
+					SignoutPath:         "/oauth2/signout",
+					ForwardBearerToken:  true,
+					AuthScopes:          []string{"user", "openid"},
+					Resources:           []string{"user", "openid"},
+				},
+			},
+		},
+		{
+			input: `
+auth:
+  scheme: oauth2
+  oauth2:
+    token_endpoint: https://oauth2.googleapis.com/token
+    authorization_endpoint: https://accounts.google.com/o/oauth2/auth
+    credentials:
+      client_id: "client_id"
+      client_secret_ref:
+        name: "some-secret-object-containing-client-id"
+        namespace: "some-namespace"
+      hmac_secret: hmac_secret
+    redirect_uri: http://localhost
+    redirect_path_matcher: /oauth2/callback
+    signout_path: /oauth2/signout
+    forward_bearer_token: true
+    auth_scopes:
+      - user
+      - openid
+    resources:
+      - user
+      - openid
+`,
+			expected: &AuthOptions{
+				Scheme: "oauth2",
+				OAuth2: &OAuth2{
+					TokenEndpoint:         "https://oauth2.googleapis.com/token",
+					AuthorizationEndpoint: "https://accounts.google.com/o/oauth2/auth",
+					Credentials: Credentials{
+						ClientID: "client_id",
+						ClientSecretRef: &ClientSecretRef{
+							Name:      "some-secret-object-containing-client-id",
+							Namespace: "some-namespace",
+						},
+						HmacSecret: "hmac_secret",
 						CookieNames: CookieNames{
 							BearerToken:  "",
 							OauthHMAC:    "",
@@ -194,4 +241,40 @@ func Test_AuthOptions_Validate_Error(t *testing.T) {
 	}
 
 	assert.EqualError(options.Validate(), "auth: (auth-upstream: (host: (hostname: cannot be blank; port: cannot be blank.).).).")
+}
+
+func Test_AuthOptions_OAuth2_Mutually_Exclusive_Client_Secret_Options(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	expected := "auth: (oauth2: (credentials: oauth2: You cannot specify both `client_secret_ref` and `client_secret`, the options are mutually exclusive.).)."
+	input := `
+auth:
+  scheme: oauth2
+  oauth2:
+    token_endpoint: https://oauth2.googleapis.com/token
+    authorization_endpoint: https://accounts.google.com/o/oauth2/auth
+    credentials:
+      client_id: "client_id"
+      client_secret: "client_secret"
+      client_secret_ref:
+        name: some-secret-object-containing-client-id
+        namespace: some-namespace
+      hmac_secret: hmac_secret
+    redirect_uri: http://localhost
+    redirect_path_matcher: /oauth2/callback
+    signout_path: /oauth2/signout
+    forward_bearer_token: true
+    auth_scopes:
+      - user
+      - openid
+    resources:
+      - user
+      - openid
+`
+	options := &SubOptions{}
+	err := yaml.UnmarshalStrict([]byte(input), options)
+	assert.NoError(err)
+
+	assert.EqualError(options.Validate(), expected)
 }


### PR DESCRIPTION
Support reading `client_secret` for OAuth2 from a Kuberenets Secret. E.g.,

```yaml
    credentials:
        client_id: "client_id"
        client_secret_ref:
          name: "some-secret-object-containing-client-id"
          namespace: "some-namespace"
```

We still support the old way of defining `client_secret`, i.e.,

```yaml
    credentials:
        client_id: "client_id"
        client_secret: "inline_client_secret"
```

You cannot specify both `client_secret_ref` and `client_secret`. An error is generated if both are specified.

---

Resolves kubeshop/kusk-gateway/issues/829.

See: <https://github.com/kubeshop/kusk-gateway/issues/829>.

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

Test
####

```sh
cd examples/auth/oauth2/client-secret-ref
make
```

Observe Envoy logs for something like this:

```sh
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.867781,"caller":"logr@v1.2.3/logr.go:261","msg":"auth.NewFilterHTTPOAuth2: getting secret","client_secret_ref":"{\"name\":\"auth-oauth2-oauth0-client-secret-ref-api\",\"namespace\":\"oauth2-secrets\"}"}
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.8678958,"caller":"logr@v1.2.3/logr.go:261","msg":"auth.NewFilterHTTPOAuth2: retrieved secret","client_secret_ref":"{\"name\":\"auth-oauth2-oauth0-client-secret-ref-api\",\"namespace\":\"oauth2-secrets\"}","secret":"<*>&Secret{ObjectMeta:{auth-oauth2-oauth0-client-secret-ref-api  oauth2-secrets  2986fe55-480b-4e76-93b1-ddd3c5ffbfb3 724 0 2022-10-06 17:37:28 +0000 UTC <nil> <nil> map[] map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"client_secret\":\"WjZNWDdOcmVKdW1XTG1mNnVuc1E1dWlFVXJUQnhmTnRxRzlWeTVLamt0bnZmai1fZlJDQk85RVUxbUwxWXpBSgo=\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"name\":\"auth-oauth2-oauth0-client-secret-ref-api\",\"namespace\":\"oauth2-secrets\"},\"type\":\"Opaque\"}\n] [] [] [{kubectl-client-side-apply Update v1 2022-10-06 17:37:28 +0000 UTC FieldsV1 {\"f:data\":{\".\":{},\"f:client_secret\":{}},\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:kubectl.kubernetes.io/last-applied-configuration\":{}}},\"f:type\":{}} }]},Data:map[string][]byte{client_secret: [90 54 77 88 55 78 114 101 74 117 109 87 76 109 102 54 117 110 115 81 53 117 105 69 85 114 84 66 120 102 78 116 113 71 57 86 121 53 75 106 107 116 110 118 102 106 45 95 102 82 67 66 79 57 69 85 49 109 76 49 89 122 65 74 10],},Type:Opaque,StringData:map[string]string{},Immutable:nil,}"}
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.8679295,"caller":"logr@v1.2.3/logr.go:261","msg":"auth.NewFilterHTTPOAuth2: set client_secret","client_secret":"Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ\n"}
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.8679845,"logger":"auth.ParseAuthOptions","caller":"auth/parser.go:107","msg":"added filter","HTTPConnectionManager.HttpFilters":6}
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.8680425,"logger":"internal/controllers/parser.go:UpdateConfigFromAPIOpts","caller":"controllers/parser.go:155","msg":"parsing `auth` options","finalOpts.Auth":"&options.AuthOptions{Scheme:\"oauth2\", PathPrefix:(*string)(nil), AuthUpstream:(*options.AuthUpstream)(nil), OAuth2:(*options.OAuth2)(0xc001538000)}"}
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.868066,"caller":"logr@v1.2.3/logr.go:261","msg":"auth.NewFilterHTTPOAuth2: getting secret","client_secret_ref":"{\"name\":\"auth-oauth2-oauth0-client-secret-ref-api\",\"namespace\":\"oauth2-secrets\"}"}
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.8681378,"caller":"logr@v1.2.3/logr.go:261","msg":"auth.NewFilterHTTPOAuth2: retrieved secret","client_secret_ref":"{\"name\":\"auth-oauth2-oauth0-client-secret-ref-api\",\"namespace\":\"oauth2-secrets\"}","secret":"<*>&Secret{ObjectMeta:{auth-oauth2-oauth0-client-secret-ref-api  oauth2-secrets  2986fe55-480b-4e76-93b1-ddd3c5ffbfb3 724 0 2022-10-06 17:37:28 +0000 UTC <nil> <nil> map[] map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"client_secret\":\"WjZNWDdOcmVKdW1XTG1mNnVuc1E1dWlFVXJUQnhmTnRxRzlWeTVLamt0bnZmai1fZlJDQk85RVUxbUwxWXpBSgo=\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"name\":\"auth-oauth2-oauth0-client-secret-ref-api\",\"namespace\":\"oauth2-secrets\"},\"type\":\"Opaque\"}\n] [] [] [{kubectl-client-side-apply Update v1 2022-10-06 17:37:28 +0000 UTC FieldsV1 {\"f:data\":{\".\":{},\"f:client_secret\":{}},\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:kubectl.kubernetes.io/last-applied-configuration\":{}}},\"f:type\":{}} }]},Data:map[string][]byte{client_secret: [90 54 77 88 55 78 114 101 74 117 109 87 76 109 102 54 117 110 115 81 53 117 105 69 85 114 84 66 120 102 78 116 113 71 57 86 121 53 75 106 107 116 110 118 102 106 45 95 102 82 67 66 79 57 69 85 49 109 76 49 89 122 65 74 10],},Type:Opaque,StringData:map[string]string{},Immutable:nil,}"}
kusk-system kusk-gateway-manager-554d5fbb7-zddr8 manager {"level":"info","ts":1665077854.8681672,"caller":"logr@v1.2.3/logr.go:261","msg":"auth.NewFilterHTTPOAuth2: set client_secret","client_secret":"Z6MX7NreJumWLmf6unsQ5uiEUrTBxfNtqG9Vy5Kjktnvfj-_fRCBO9EU1mL1YzAJ\n"}
```