### PR TITLE
extended kusk version

### DIFF
--- a/cmd/kusk/cmd/version.go
+++ b/cmd/kusk/cmd/version.go
@@ -65,7 +65,7 @@ func NewVersionCommand(writer io.Writer, version string) *cobra.Command {
 				}
 			}
 
-			fmt.Fprintf(writer, "%s\n", formattedVersion)
+			fmt.Fprintf(writer, "%s\n\n", formattedVersion)
 
 			c, err := utils.GetK8sClient()
 			if err != nil {
@@ -77,21 +77,18 @@ func NewVersionCommand(writer io.Writer, version string) *cobra.Command {
 				reportError(err)
 				return err
 			}
-			versions := []string{}
-			for _, deployment := range deployments.Items {
-				//spec.template.spec.containers[].image
-				name := fmt.Sprintf("%s: ", deployment.Name)
 
+			for _, deployment := range deployments.Items {
+				fmt.Printf("%s: ", deployment.Name)
+
+				images := []string{}
 				for _, container := range deployment.Spec.Template.Spec.Containers {
 					if len(container.Image) > 0 {
-						name = name + ", " + container.Image
+						images = append(images, container.Image)
 					}
 				}
-
-				versions = append(versions, name)
+				fmt.Println("", strings.Join(images, ", "))
 			}
-
-			fmt.Println(strings.Join(versions, "\n"))
 			return nil
 		},
 	}


### PR DESCRIPTION
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>
fixes #810 

```
# go run main.go version
Kusk version 
https://github.com/kubeshop/kusk-gateway/releases/latest

kusk-gateway-manager:  kubeshop/kusk-gateway:v1.3.3, gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
kusk-gateway-api:  kubeshop/kusk-gateway-api:v1.1.5
kusk-gateway-envoy-fleet:  docker.io/envoyproxy/envoy:v1.23.1
kusk-gateway-private-envoy-fleet:  docker.io/envoyproxy/envoy:v1.23.1
kusk-gateway-dashboard:  kubeshop/kusk-gateway-dashboard:v1.2.0
```
