### PR TITLE
`make create-env`: Use `minikube image load`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,13 +152,14 @@ run: install-deps install-local generate fmt vet ## Run a controller from your h
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	eval $$(minikube docker-env --profile kgw); docker build \
+	docker build \
 		--tag ${MANAGER_IMG} \
 		--tag kusk-gateway:latest \
 		--tag kubeshop/kusk-gateway:latest \
 		--tag kubeshop/kusk-gateway:$(shell git describe --tags $(shell git rev-list --tags --max-count=1)) \
 		--file ./build/manager/Dockerfile \
 		.
+	minikube image --profile kgw load kubeshop/kusk-gateway:$(shell git describe --tags $(shell git rev-list --tags --max-count=1))
 
 ##@ Deployment
 


### PR DESCRIPTION
Instead of building the image in the `minikube` docker environment, build it on the host. I.e., remove  `eval $$(minikube docker-env --profile kgw); docker build` in favour of:

```sh
$ docker build ...
$ minikube image --profile kgw load kubeshop/kusk-gateway:$(git describe --tags $(git rev-list --tags --max-count=1))
```

This should result in faster builds if you delete the `minikube` cluster and re-create as the `kubeshop/kusk-gateway:$(git describe --tags $(git rev-list --tags --max-count=1))` images are not being built in the `minikube` docker daemon so its layers are cached.

Results
-------

I benchmarked the changes:

**Old**:

```sh
$ hyperfine --runs 3 'minikube delete --profile kgw && time make create-env'
Benchmark 1: minikube delete --profile kgw && time make create-env
  Time (mean ± σ):     97.866 s ±  2.965 s    [User: 32.466 s, System: 7.927 s]
  Range (min … max):   94.516 s … 100.156 s    3 runs
```

**New**:

```sh
$ hyperfine --runs 3 'minikube delete --profile kgw && time make create-env'
Benchmark 1: minikube delete --profile kgw && time make create-env
  Time (mean ± σ):     65.146 s ±  0.983 s    [User: 30.162 s, System: 6.345 s]
  Range (min … max):   64.340 s … 66.241 s    3 runs
```

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

Could you please try out this branch to ensure it works in whatever setup you use.