### PR TITLE
fixing help content

### DIFF
--- a/cmd/kusk/cmd/generate.go
+++ b/cmd/kusk/cmd/generate.go
@@ -241,8 +241,7 @@ func init() {
 }
 
 var generateDescription = `Description:
-
-"kusk generate" accepts your OpenAPI spec file as input either as a local file or a URL and generates a Kusk 
+Generate accepts your OpenAPI spec file as input either as a local file or a URL and generates a Kusk 
 Gateway compatible API resource that you can apply directly into your cluster. 
 
 It does this via the x-kusk extension which will be added automatically if one is not already set. It will 
@@ -253,27 +252,41 @@ If the x-kusk extension is already present, it will override the upstream servic
 the flag values passed, respectively, and leave the rest of the settings as they are.`
 
 var generateHelp = `
-Example:
-
-kusk generate -i spec.yaml
-
-OpenAPI definition form URL:
-This will fetch the OpenAPI document from the provided URL and generate a Kusk Gateway API resource
-
-kusk api generate -i https://raw.githubusercontent.com/kubeshop/kusk-gateway/main/examples/todomvc/spec/todospec.yaml
-
-Specifying additional information:
+No Name Specified:
+The OpenAPI definition info.title property is used to generate a manifest name.
 
 kusk generate \
-	-i spec.yaml \
-	--name httpbin-api \
-	--upstream.service httpbin \
-	--upstream.port 8080 \
-	--envoyfleet.name kusk-gateway-envoy-fleet \
-	--envoyfleet.namespace kusk-system
+  -i spec.yaml \
+  --envoyfleet.name kusk-gateway-envoy-fleet \
+  --envoyfleet.namespace kusk-system
 
-In the above example, kusk will use the openapi spec info.title to generate a manifest name and leave the existing
-x-kusk extension settings
+No API Name Specified:
+As --namespace isn't defined, the default namespace will be used.
 
-In the above example, as --namespace isn't defined, it will assume the default namespace.
-`
+kusk generate \
+  -i spec.yaml \
+  --name httpbin-api \
+  --upstream.service httpbin \
+  --upstream.port 8080 \
+  --envoyfleet.name kusk-gateway-envoy-fleet
+
+Namespace Specified:
+kusk generate \
+  -i spec.yaml \
+  --name httpbin-api \
+  --upstream.service httpbin \
+  --upstream.namespace my-namespace \
+  --upstream.port 8080 \
+  --envoyfleet.name kusk-gateway-envoy-fleet
+
+OpenAPI Definition from URL:
+Fetches the OpenAPI document from the provided URL and generates a Kusk Gateway API resource.
+
+kusk generate \
+   -i https://raw.githubusercontent.com/$ORG_OR_USER/$REPO/myspec.yaml \
+   --name httpbin-api \
+   --upstream.service httpbin \
+   --upstream.namespace my-namespace \
+   --upstream.port 8080 \
+   --envoyfleet.name kusk-gateway-envoy-fleet
+   `

--- a/cmd/kusk/cmd/mock.go
+++ b/cmd/kusk/cmd/mock.go
@@ -468,28 +468,55 @@ real API would return from your content schema or defined examples.
 Note: Kusk mock prioritises examples over schema definitions.
 `
 
-var mockHelp = `Schema example: 
- content:
-  application/json:
-   schema:
-	type: object
-	properties:
-	 title:
-	  type: string
-	  description: Description of what to do
-	 completed:
-	  type: boolean
-	 order:
-	  type: integer
-	  format: int32
-	 url:
-	  type: string
-	  format: uri
-	required:
-	 - title
-	 - completed
-	 - order
-	 - url
+var mockHelp = `
+Mock Command:
+kusk mock -i path-to-openapi-file.yaml
+kusk mock -i https://url.to.api.com
+
+Schema example: 
+openapi: 3.0.0
+info:
+  title: todo-backend-api
+  version: 0.0.2
+paths:
+  /todos:
+    get:
+      responses:
+        '200':
+          description: 'ToDos'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  title:
+                    type: string
+                    description: Description of what to do
+                  completed:
+                    type: boolean
+                  order:
+                    type: integer
+                    format: int32
+                  url:
+                    type: string
+                    format: uri
+                required:
+                  - title
+                  - completed
+                  - order
+                  - url
+            application/xml:
+              example:
+                title: "Mocked XML title"
+                completed: true
+                order: 13
+                url: "http://mockedURL.com"
+            text/plain:
+              example: |
+                title: "Mocked Text title"
+                completed: true
+                order: 13
+                url: "http://mockedURL.com"
  
 Generated JSON Response: 
 {
@@ -514,7 +541,13 @@ XML Respose from Defined Examples:
   <title>Mocked XML title</title>
   <url>http://mockedURL.com</url>
  </doc>
- 
+
+Plain Text Response from Defined Examples:
+title: "Mocked Text title"
+completed: true
+order: 13
+url: "http://mockedURL.com"
+
 Stop Mock Server: 
 ctrt+c
 `

--- a/cmd/kusk/cmd/mock.go
+++ b/cmd/kusk/cmd/mock.go
@@ -463,10 +463,11 @@ func init() {
 }
 
 var mockDescription = `Description:
-
 Spins up a local mock API server that imitates a real API server. It does this by generating responses like the
 real API would return from your content schema or defined examples.
-Note: Kusk mock prioritises examples over schema definitions.`
+Note: Kusk mock prioritises examples over schema definitions.
+`
+
 var mockHelp = `Schema example: 
  content:
   application/json:

--- a/cmd/kusk/cmd/root.go
+++ b/cmd/kusk/cmd/root.go
@@ -211,11 +211,13 @@ func help(c *cobra.Command, s []string) {
 	case mockCmd.Use:
 		fmt.Println("")
 		mockDescription = strings.Replace(mockDescription, "Description:", kuskui.Gray("Description:"), 1)
+		mockHelp = strings.Replace(mockHelp, "Mock Command:", kuskui.Gray("Mock Command:"), 1)
 		mockHelp = strings.Replace(mockHelp, "Schema example:", kuskui.Gray("Schema example:"), 1)
 		mockHelp = strings.Replace(mockHelp, "Generated JSON Response:", kuskui.Gray("Generated JSON Response:"), 1)
 		mockHelp = strings.Replace(mockHelp, "Generated XML Response:", kuskui.Gray("Generated XML Response:"), 1)
 		mockHelp = strings.Replace(mockHelp, "XML Respose from Defined Examples:", kuskui.Gray("XML Respose from Defined Examples:"), 1)
 		mockHelp = strings.Replace(mockHelp, "Stop Mock Server:", kuskui.Gray("Stop Mock Server:"), 1)
+		mockHelp = strings.Replace(mockHelp, "Plain Text Response from Defined Examples:", kuskui.Gray("Plain Text Response from Defined Examples:"), 1)
 
 		fmt.Println(mockDescription)
 		fmt.Println(mockHelp)

--- a/cmd/kusk/cmd/root.go
+++ b/cmd/kusk/cmd/root.go
@@ -223,11 +223,10 @@ func help(c *cobra.Command, s []string) {
 	case generateCmd.Use:
 		fmt.Println("")
 		generateDescription = strings.Replace(generateDescription, "Description:", kuskui.Gray("Description:"), 1)
-		generateHelp = strings.Replace(generateHelp, "Example:", kuskui.Gray("Example:"), 1)
 		generateHelp = strings.Replace(generateHelp, "No name specified:", kuskui.Gray("No name specified::"), 1)
-		generateHelp = strings.Replace(generateHelp, "OpenAPI definition form URL:", kuskui.Gray("OpenAPI definition form URL:"), 1)
-		generateHelp = strings.Replace(generateHelp, "Specifying additional information:", kuskui.Gray("Specifying additional information:"), 1)
-		generateHelp = strings.Replace(generateHelp, "Namespace specified:", kuskui.Gray("Namespace specified:"), 1)
+		generateHelp = strings.Replace(generateHelp, "No API Name Specified:", kuskui.Gray("No API Name Specified:"), 1)
+		generateHelp = strings.Replace(generateHelp, "Namespace Specified:", kuskui.Gray("Namespace Specified:"), 1)
+		generateHelp = strings.Replace(generateHelp, "OpenAPI Definition from URL:", kuskui.Gray("OpenAPI Definition from URL:"), 1)
 
 		fmt.Println(generateDescription)
 		fmt.Println(generateHelp)
@@ -251,7 +250,7 @@ func help(c *cobra.Command, s []string) {
 	kuskui.PrintInfo(usage)
 	kuskui.PrintInfoGray(kuskui.Gray("Flags"))
 	kuskui.PrintInfo(c.Flags().FlagUsages())
-	kuskui.PrintInfo(kuskui.Gray("Use \"kusk [command] --help\" for more information about a command."))
+	kuskui.PrintInfo("Use \"kusk [command] --help\" for more information about a command.")
 	fmt.Println("")
 	kuskui.PrintInfo(fmt.Sprintf("%s   %s", kuskui.Gray("Docs & Support:"), "https://docs.kusk.io/"))
 	fmt.Println("")


### PR DESCRIPTION
Reverted help messages for generate and mock so they are exactly like provided https://www.figma.com/file/EkNk9tMEoAgYrwGP7N1dPm/Kusk-CLI?node-id=166%3A779


Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>
