### PR TITLE
https://skaffold.dev: debug launch settings, GitHub Actions workflow and caching in `Dockerfile`

### DIFF
--- a/.github/workflows/skaffold.yaml
+++ b/.github/workflows/skaffold.yaml
@@ -1,0 +1,90 @@
+name: skaffold
+on: [push]
+env:
+  GO_VERSION: "1.19.2"
+  # https://minikube.sigs.k8s.io/docs/faq/#can-i-get-rid-of-the-emoji-in-minikubes-output
+  MINIKUBE_IN_STYLE: 0
+  MINIKUBE_VERSION: "v1.26.1"
+  # KUBERNETES_VERSION: "v1.23.3" # Not currently used
+
+jobs:
+  download-binaries:
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: download-dependencies
+        # continue-on-error: false
+        run: |
+          sudo apt-get install -y curl
+      - name: download-minikube
+        run: |
+          ARCH="$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64")"
+          curl -LO https://storage.googleapis.com/minikube/releases/${{env.MINIKUBE_VERSION}}/minikube-linux-amd64
+          sudo install minikube-linux-amd64 /usr/local/bin/minikube
+          rm minikube-linux-amd64
+      - uses: actions/upload-artifact@v3
+        with:
+          name: minikube
+          path: /usr/local/bin/minikube
+      - name: download-kubectl
+        run: |
+          ARCH="$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64")"
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl"
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          kubectl version --client=true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: kubectl
+          path: /usr/local/bin/kubectl
+      - name: download-skaffold
+        run: |
+          ARCH="$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64")"
+          sudo curl -L --output /usr/local/bin/skaffold "https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-${ARCH}"
+          sudo chmod +x /usr/local/bin/skaffold
+      - uses: actions/upload-artifact@v3
+        with:
+          name: skaffold
+          path: /usr/local/bin/skaffold
+  e2e:
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    needs: download-binaries
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: minikube
+          # path: /usr/local/bin/minikube
+      - uses: actions/download-artifact@v3
+        with:
+          name: kubectl
+          # path: /usr/local/bin/kubectl
+      - uses: actions/download-artifact@v3
+        with:
+          name: skaffold
+          # path: /usr/local/bin/skaffold
+      - name: minikube-start
+        run: |
+          minikube start --profile kgw --addons=metallb
+          echo
+          kubectl get svc -A
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: skaffold-run
+        run: |
+          ./skaffold.sh run
+          echo
+          sleep 8
+          echo
+          kubectl get svc -A
+      - name: e2e-download-dependencies
+        run: |
+          sudo apt-get install -y make
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: e2e-run
+        run: |
+          make check-all

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    // https://skaffold.dev/docs/workflows/debug/
+    {
+      "name": "Skaffold Debug",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "port": 56268,
+      "host": "127.0.0.1",
+      "apiVersion": 2,
+      // "trace": "trace",
+      "substitutePath": [
+        {
+          "from": "${workspaceFolder}",
+          "to": "/workspace",
+        },
+      ],
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ docs-preview: ## Preview the documentation
 
 .PHONY: tail-logs
 tail-logs: install-deps ## Tail logs of all containers across all namespaces
+	go install github.com/stern/stern@latest
+	@# Optionally `source <(stern --completion=zsh)` in your `~/.zshrc`.
 	stern --all-namespaces --selector app.kubernetes.io/name
 
 .PHONY: tail-xds
@@ -145,11 +147,6 @@ testing: ## Run the integration tests from development/testing and then delete t
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager -ldflags="${LD_FLAGS}" cmd/manager/main.go
 
-.PHONY: run
-run: install-deps install-local generate fmt vet ## Run a controller from your host, proxying it inside the cluster.
-	go build -o bin/manager cmd/manager/main.go
-	ktunnel expose -n kusk-system kusk-xds-service 18000 & ENABLE_WEBHOOKS=false bin/manager ; fg
-
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
 	docker build \
@@ -222,9 +219,6 @@ check-all: install-deps $(smoketests)
 
 .PHONY: install-deps
 install-deps:
-	go install github.com/omrikiei/ktunnel@v1.4.7
-	go install github.com/stern/stern@latest
-	@# Optionally `source <(stern --completion=zsh)` in your `~/.zshrc`.
 	go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.2
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2

--- a/build/manager/Dockerfile
+++ b/build/manager/Dockerfile
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:experimental
+
 # Build the manager binary
 FROM --platform=$BUILDPLATFORM docker.io/golang:1.19 as builder
 
@@ -9,7 +11,9 @@ COPY go.sum go.sum
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN \
+  --mount=type=cache,target=/go/pkg/mod \
+  go mod download
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -22,7 +26,11 @@ ARG SKAFFOLD_GO_GCFLAGS
 COPY . .
 
 # Build
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -v -ldflags "-X 'github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN' -X 'github.com/kubeshop/kusk-gateway/pkg/build.Version=$VERSION'" -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o manager cmd/manager/main.go
+RUN \
+  --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=cache,target=/root/.cache/go-build \
+  GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 \
+  go build -v -ldflags "-X 'github.com/kubeshop/kusk-gateway/pkg/analytics.TelemetryToken=$TELEMETRY_TOKEN' -X 'github.com/kubeshop/kusk-gateway/pkg/build.Version=$VERSION'" -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o manager cmd/manager/main.go
 
 # Directory for the files created and used by the manager, to be copied for static rootless images since we don't have shell to create it there
 RUN mkdir -m 00755 /opt/manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: kusk-gateway-manager
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsNonRoot: false
       containers:
         - command:
             - /manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: kusk-gateway-manager
     spec:
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
       containers:
         - command:
             - /manager

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	k8s.io/component-helpers v0.25.0 // indirect
 	k8s.io/metrics v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -504,7 +504,6 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -554,8 +553,6 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
-github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=

--- a/skaffold.sh
+++ b/skaffold.sh
@@ -6,8 +6,6 @@ set -o errexit  # Used to exit upon error, avoiding cascading errors
 set -o pipefail # Unveils hidden failures
 set -o nounset  # Exposes unset variables
 
-PROFILE="${PROFILE:-kgw}"
-
 install_and_configure_skaffold() {
   ARCH="$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64")"
   sudo curl -L --output /usr/local/bin/skaffold "https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-${ARCH}"
@@ -20,6 +18,8 @@ install_and_configure_skaffold() {
   mkdir -pv /tmp/skaffold || echo '`/tmp/skaffold` already exist - skipping create'
 }
 skaffold version || install_and_configure_skaffold
+
+PROFILE="${PROFILE:-kgw}"
 
 kustomize build config/crd >/tmp/skaffold/config-crd.yaml
 # For debugging support changing this value, otherwise we get this error:

--- a/skaffold.sh
+++ b/skaffold.sh
@@ -8,7 +8,18 @@ set -o nounset  # Exposes unset variables
 
 PROFILE="${PROFILE:-kgw}"
 
-mkdir -pv /tmp/skaffold || echo '`/tmp/skaffold` already exist - skipping create'
+install_and_configure_skaffold() {
+  ARCH="$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64")"
+  sudo curl -L --output /usr/local/bin/skaffold "https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-${ARCH}"
+  sudo chmod +x /usr/local/bin/skaffold
+  echo
+  skaffold version
+  echo
+  skaffold config set --global local-cluster true
+  echo
+  mkdir -pv /tmp/skaffold || echo '`/tmp/skaffold` already exist - skipping create'
+}
+skaffold version || install_and_configure_skaffold
 
 kustomize build config/crd >/tmp/skaffold/config-crd.yaml
 # For debugging support changing this value, otherwise we get this error:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,6 +2,7 @@ apiVersion: skaffold/v2beta29
 kind: Config
 build:
   local:
+    useBuildkit: true
     push: false
   tagPolicy:
     sha256: {}


### PR DESCRIPTION
`.github/workflows/skaffold.yaml`
---------------------------------

Build using <https://skaffold.dev> using `minikube`.

`.vscode/launch.json`
---------------------

Skaffold Debug laucnh settings for VSCode.

`build/manager/Dockerfile`
-------------------------

Use build kit cache to speed up image build times

See:

* <https://m0sh1x2.com/posts/optimizing-local-go-kubernetes-deployments/>.
* <https://www.sobyte.net/post/2022-06/docker-buildkit/>.

`Makefile`
----------

Remove `run` target and `ktunnel` dependency as we can use <https://skaffold.dev> now.

Signed-off-by: Mohamed Bana <mohamed@bana.io>