### PR TITLE
Reintroduce disabled feature

### DIFF
--- a/config/samples/gateway_v1_api.yaml
+++ b/config/samples/gateway_v1_api.yaml
@@ -43,7 +43,7 @@ spec:
           description: Find out more about our store
           url: 'http://swagger.io'
     x-kusk:
-      hidden: false
+      disabled: false
       cors:
         origins:
         - "*"
@@ -72,10 +72,10 @@ spec:
     paths:
       /pet:
         x-kusk:
-          hidden: true
+          disabled: true
         post:
           x-kusk:
-            hidden: false
+            disabled: false
             upstream:
               host:
                 hostname: petstore1.default1.svc.cluster.local
@@ -196,7 +196,7 @@ spec:
       '/pet/{petId}':
         get:
           x-kusk:
-            hidden: false
+            disabled: false
             cors:
               origins:
               - "http://example.com"

--- a/development/petshop-openapi-short-with-kusk-and-mock.yaml
+++ b/development/petshop-openapi-short-with-kusk-and-mock.yaml
@@ -36,7 +36,7 @@ x-kusk:
   hosts: 
   - "*"
   - "example.org"
-  hidden: false
+  disabled: false
   cors:
     origins:
     - "*"
@@ -64,10 +64,10 @@ x-kusk:
 paths:
   /pet:
     x-kusk:
-      hidden: true
+      disabled: true
     post:
       x-kusk:
-        hidden: false
+        disabled: false
         host:
           hostname: petstore1.default1.svc.cluster.local
           port: 8080
@@ -240,7 +240,7 @@ paths:
     # This paths is mocked!
     get:
       x-kusk:
-        hidden: false
+        disabled: false
         # Routing to mocking here
         upstream:
           service:

--- a/development/petshop-openapi-short-with-kusk.yaml
+++ b/development/petshop-openapi-short-with-kusk.yaml
@@ -36,7 +36,7 @@ x-kusk:
   hosts: 
   - "*"
   - "example.org"
-  hidden: false
+  disabled: false
   cors:
     origins:
     - "*"
@@ -64,10 +64,10 @@ x-kusk:
 paths:
   /pet:
     x-kusk:
-      hidden: true
+      disabled: true
     post:
       x-kusk:
-        hidden: false
+        disabled: false
         upstream:
           host:
             hostname: petstore1.default1.svc.cluster.local
@@ -240,7 +240,7 @@ paths:
   '/pet/{petId}':
     get:
       x-kusk:
-        hidden: false
+        disabled: false
         cors:
           origins:
           - "http://example.com"

--- a/development/testing/manifests/api-second.yaml
+++ b/development/testing/manifests/api-second.yaml
@@ -15,7 +15,7 @@ spec:
       version: 1.0.0
     x-kusk:
       hosts: [ "example.org"]
-      hidden: true
+      disabled: true
       cors:
         origins:
           - 'http://example.org'
@@ -43,7 +43,7 @@ spec:
         get:
           # All GET are redirected to usual API with the rewrite (/second/todos/2 -> /testing/todos/2)
           x-kusk:
-            hidden: false
+            disabled: false
             redirect:
               host_redirect: "example.com"
               rewrite_regex:
@@ -200,7 +200,7 @@ spec:
         get:
           # Enable only GET
           x-kusk:
-            hidden: false
+            disabled: false
           responses:
             '200':
               description: The full list of todos
@@ -297,7 +297,7 @@ spec:
             - Todo
         delete:
           x-kusk:
-            hidden: true
+            disabled: true
           responses:
             '200':
               description: ''

--- a/docs/docs/extension.md
+++ b/docs/docs/extension.md
@@ -417,16 +417,16 @@ This will expose your entire OpenAPI definition, without the Kusk extensions, on
 
 To remove some paths or operations from the exposed OpenAPI, use the [`disabled` option](./#disabled).
 
-### **Hidden**
+### **Disabled**
 
-This boolean property allows you to hide the corresponding path/operation from being added to the [exposed OpenAPI definition](#exposing-openapi-defintion) when the `public_api_path` is set to `true`.
+This boolean property allows you to hide the corresponding path/operation from being exposed and managed by Kusk.
 
-When set to true at the top level, all paths will be hidden; you will have to override specific paths/operations with `hidden: false` to make those operations visible.
+When set to true at the top level, all paths will be disabled; you will have to override specific paths/operations with `disabled: false` to make those operations visible.
 
 ```yaml title="openapi.yaml"
 ...
   /path:
     x-kusk:
-      hidden: true
+      disabled: true
 ...
 ```

--- a/examples/httpbin/httpbin_v1_api.yaml
+++ b/examples/httpbin/httpbin_v1_api.yaml
@@ -111,7 +111,7 @@ spec:
       "/xml":
         # Disable this path for test
         x-kusk:
-          hidden: true
+          disabled: true
         get:
           description: Returns some XML.
           operationId: "/xml"

--- a/internal/controllers/parser.go
+++ b/internal/controllers/parser.go
@@ -110,7 +110,7 @@ func UpdateConfigFromAPIOpts(
 		for method, operation := range pathItem.Operations() {
 
 			finalOpts := opts.OperationFinalSubOptions[method+path]
-			if finalOpts.Hidden != nil && *finalOpts.Hidden {
+			if finalOpts.Disabled != nil && *finalOpts.Disabled {
 				continue
 			}
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 Kubeshop
+# Copyright (c) 2022 Kubeshop
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -111,7 +111,7 @@ func (o Options) Validate() error {
 
 // SubOptions allow user to overwrite certain options at path/operation level using x-kusk extension
 type SubOptions struct {
-	Hidden *bool `yaml:"hidden,omitempty" json:"hidden,omitempty"`
+	Disabled *bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 	// Upstream is a set of options of a target service to receive traffic.
 	Upstream *UpstreamOptions `yaml:"upstream,omitempty" json:"upstream,omitempty"`
 	// Redirect specifies thre redirect optins, mutually exclusive with Upstream
@@ -135,7 +135,7 @@ func (o SubOptions) Validate() error {
 	}
 	// fail if doesn't have upstream or redirect and is "enabled"
 	if o.Upstream == nil && o.Redirect == nil {
-		if o.Hidden != nil && !*o.Hidden {
+		if o.Disabled != nil && !*o.Disabled {
 			return fmt.Errorf("either Upstream or Service must be specified")
 		}
 	}
@@ -153,8 +153,8 @@ func (o SubOptions) Validate() error {
 
 // MergeInSubOptions handles merging other SubOptions (usually - upper level in root/path/method hierarchy)
 func (o *SubOptions) MergeInSubOptions(in *SubOptions) {
-	if o.Hidden == nil && in.Hidden != nil {
-		o.Hidden = in.Hidden
+	if o.Disabled == nil && in.Disabled != nil {
+		o.Disabled = in.Disabled
 	}
 	if o.Upstream == nil && o.Redirect == nil {
 		if in.Upstream != nil {

--- a/pkg/spec/extension.go
+++ b/pkg/spec/extension.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2022 Kubeshop
+# Copyright (c) 2022 Kubeshop
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -110,11 +110,11 @@ func PostProcessedDef(apiSpec openapi3.T, opt options.Options) *openapi3.T {
 	for path, pathItem := range apiSpec.Paths {
 		pathOptions, _, _ := getPathOptions(pathItem)
 		for method := range pathItem.Operations() {
-			if pathOptions.Hidden != nil && *pathOptions.Hidden {
+			if pathOptions.Disabled != nil && *pathOptions.Disabled {
 				item := &openapi3.PathItem{}
 				fOpt := opt.OperationFinalSubOptions[method+path]
-				if fOpt.Hidden != nil && !*fOpt.Hidden {
-					if pathOptions.Hidden != nil && *pathOptions.Hidden {
+				if fOpt.Disabled != nil && !*fOpt.Disabled {
+					if pathOptions.Disabled != nil && *pathOptions.Disabled {
 						if item = parsePathItem(pathItem); len(item.Operations()) > 0 {
 							postProcessed.Paths[path] = item
 						}
@@ -135,12 +135,12 @@ func parsePathItem(pathItem *openapi3.PathItem) (result *openapi3.PathItem) {
 	delete(result.ExtensionProps.Extensions, kuskExtensionKey)
 	for operation, oper := range pathItem.Operations() {
 		opts, _, _ := getOperationOptions(oper)
-		if opts.Hidden != nil && !*opts.Hidden {
+		if opts.Disabled != nil && !*opts.Disabled {
 			delete(oper.ExtensionProps.Extensions, kuskExtensionKey)
 			result.SetOperation(operation, oper)
-		} else if opts.Hidden != nil && *opts.Hidden {
+		} else if opts.Disabled != nil && *opts.Disabled {
 			result.SetOperation(operation, nil)
-		} else if opts.Hidden == nil {
+		} else if opts.Disabled == nil {
 			result.SetOperation(operation, nil)
 		}
 

--- a/pkg/spec/extension_test.go
+++ b/pkg/spec/extension_test.go
@@ -56,7 +56,7 @@ func TestGetOptions(t *testing.T) {
 					"/pet": &openapi3.PathItem{
 						ExtensionProps: openapi3.ExtensionProps{
 							Extensions: map[string]interface{}{
-								kuskExtensionKey: json.RawMessage(`{"hidden":true}`),
+								kuskExtensionKey: json.RawMessage(`{"disabled":true}`),
 							},
 						},
 						Get: &openapi3.Operation{},
@@ -66,7 +66,7 @@ func TestGetOptions(t *testing.T) {
 			res: options.Options{
 				OperationFinalSubOptions: map[string]options.SubOptions{
 					"GET/pet": {
-						Hidden: &trueValue,
+						Disabled: &trueValue,
 					},
 				},
 			},
@@ -79,7 +79,7 @@ func TestGetOptions(t *testing.T) {
 						Put: &openapi3.Operation{
 							ExtensionProps: openapi3.ExtensionProps{
 								Extensions: map[string]interface{}{
-									kuskExtensionKey: json.RawMessage(`{"hidden":true}`),
+									kuskExtensionKey: json.RawMessage(`{"disabled":true}`),
 								},
 							},
 						},
@@ -89,7 +89,7 @@ func TestGetOptions(t *testing.T) {
 			res: options.Options{
 				OperationFinalSubOptions: map[string]options.SubOptions{
 					"PUT/pet": {
-						Hidden: &trueValue,
+						Disabled: &trueValue,
 					},
 				},
 			},

--- a/smoketests/basic/api.yaml
+++ b/smoketests/basic/api.yaml
@@ -111,7 +111,7 @@ spec:
       "/xml":
         # Disable this path for test
         x-kusk:
-          hidden: true
+          disabled: true
         get:
           description: Returns some XML.
           operationId: "/xml"


### PR DESCRIPTION
This PR reintroduces `x-kusk.disabled` Policy, as I mistakenly understood the way it worked and only assumed it removed the path from being exposed with the `x-kusk.public_api_path`. 

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
