### PR TITLE
make suggested commands easily copied

### DIFF
--- a/cmd/kusk/cmd/install.go
+++ b/cmd/kusk/cmd/install.go
@@ -127,9 +127,7 @@ var installCmd = &cobra.Command{
 
 		if len(deployments.Items) != 0 {
 			kuskui.PrintInfo("Kusk is already installed in the cluster.\n")
-			kuskui.PrintInfo("Skipped installation.\n")
-			printPortForwardInstructions(false)
-			os.Exit(0)
+			kuskui.PrintInfo("Reinstalling components.\n")
 		}
 
 		kuskui.PrintInfo("🚀 Installing Kusk in your cluster")

--- a/cmd/kusk/cmd/ip.go
+++ b/cmd/kusk/cmd/ip.go
@@ -112,12 +112,12 @@ var ipCmd = &cobra.Command{
 		}
 		//kubectl port-forward svc/kusk-gateway-dashboard -n kusk-system 8080:80
 		if svc.Spec.Type == "ClusterIP" {
-			err := fmt.Errorf("your envoyfleet doesn't have a public IP address assigned. Try port-forwarding %q", fmt.Sprintf("kubectl port-forward svc/%s  -n %s 8080:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port))
+			err := fmt.Errorf("EnvoyFleet doesn't have an External IP address assigned. Try port-forwarding by running the following command: \n\n %s", fmt.Sprintf("kubectl port-forward svc/%s  -n %s 8080:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port))
 			reportError(err)
 			return err
 		}
 		if ip == "" {
-			err := fmt.Errorf("your envoyfleet doesn't have a public IP address assigned yet retry or try port-forwarding %q", fmt.Sprintf("kubectl port-forward svc/%s  -n %s 8080:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port))
+			err := fmt.Errorf("EnvoyFleet doesn't have an External IP address assigned yet. Retry or try port-forwarding by running the following command: \n\n %s", fmt.Sprintf("kubectl port-forward svc/%s  -n %s 8080:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port))
 			reportError(err)
 			return err
 

--- a/cmd/kusk/cmd/root.go
+++ b/cmd/kusk/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -60,8 +61,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		analytics.SendAnonymousCMDInfo(nil)
 
-		if isatty.IsTerminal(os.Stdout.Fd()) == true &&
-			build.Version != "latest" {
+		if isatty.IsTerminal(os.Stdout.Fd()) == true && build.Version != "latest" {
 
 			if len(build.Version) != 0 {
 				ghclient, err := utils.NewGithubClient("", nil)
@@ -88,10 +88,21 @@ var rootCmd = &cobra.Command{
 					return
 				}
 
-				if currentVersion != nil && currentVersion.LessThan(latestVersion) {
-					kuskui.PrintWarning(fmt.Sprintf("This version %s of Kusk cli is outdated. The latest version available is %s\n", currentVersion, latestVersion), "Please follow instructions to update you installation: https://docs.kusk.io/reference/cli/overview/#updating")
-					return
+				// if currentVersion != nil && currentVersion.LessThan(latestVersion) {
+				kuskui.PrintWarning(fmt.Sprintf("This version %s of Kusk cli is outdated. The latest version available is %s", currentVersion, latestVersion))
+
+				if runtime.GOOS == "windows" {
+					kuskui.PrintWarning(fmt.Sprintf("Run the following command to update Kusk CLI. \n\n go install -x github.com/kubeshop/kusk-gateway/cmd/kusk@latest	\n kusk cluster upgrade\n"))
 				}
+				if runtime.GOOS == "linux" {
+					kuskui.PrintWarning(fmt.Sprintf("Run the following command to update Kusk CLI. \n\n curl -sSLf https://raw.githubusercontent.com/kubeshop/kusk-gateway/main/cmd/kusk/scripts/install.sh | bash \n kusk cluster upgrade\n"))
+				}
+				if runtime.GOOS == "darwin" {
+					kuskui.PrintWarning(fmt.Sprintf("Run the following command to update Kusk CLI. \n\n brew install kubeshop/kusk/kusk \n kusk cluster upgrade\n"))
+				}
+
+				return
+				// }
 			}
 		}
 	},

--- a/cmd/kusk/cmd/version.go
+++ b/cmd/kusk/cmd/version.go
@@ -114,7 +114,7 @@ func NewVersionCommand(writer io.Writer, version string) *cobra.Command {
 			}
 
 			if outdated {
-				fmt.Println(kuskui.Red("ℹ️ Outdated Kusk version."), "Please run 'kusk cluster upgrade'")
+				fmt.Println(kuskui.Red("\nℹ️  Outdated Kusk version in your cluster."), "\nPlease run the following command to update your cluster \n\n kusk cluster upgrade\n")
 			}
 			return nil
 		},


### PR DESCRIPTION
- don't stop reinstallation
- put command in a different line to make easy to copy

Puts suggested command in a different line and suggests update command by operating system

<img width="1315" alt="image" src="https://user-images.githubusercontent.com/27779735/196802282-f91d10e5-f2ba-45e5-b82f-bb091c4339a1.png">

<img width="884" alt="image" src="https://user-images.githubusercontent.com/27779735/196802368-833c09bd-8361-4fe1-ae05-299fff7dca97.png">

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/27779735/196802521-73646c6f-e132-4a3c-9958-739301cd43cb.png">


## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
