### PR TITLE
Validation check order

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -83,22 +83,29 @@ func (o Options) Validate() error {
 	// therefore we need to iterate over all operations and check if they have either mocking or an upstream service
 
 	for pathAndMethod, op := range o.OperationFinalSubOptions {
+		if op.Disabled != nil {
+			continue
+		}
+
 		if op.Mocking != nil {
 			if err := op.Mocking.Validate(); err != nil {
 				return err
 			}
-		}
-
-		if op.Upstream != nil {
-			if err := op.Upstream.Validate(); err != nil {
-				return err
-			}
+			continue
 		}
 
 		if op.Redirect != nil {
 			if err := op.Redirect.Validate(); err != nil {
 				return err
 			}
+			continue
+		}
+
+		if op.Upstream != nil {
+			if err := op.Upstream.Validate(); err != nil {
+				return err
+			}
+			continue
 		}
 
 		// if we reach here then this path that doesn't have either mocking or an upstream service and is not covered by a
@@ -131,7 +138,7 @@ type SubOptions struct {
 
 func (o SubOptions) Validate() error {
 	if o.Upstream != nil && o.Redirect != nil {
-		return fmt.Errorf("upstream and service are mutually exclusive")
+		return fmt.Errorf("upstream and redirect are mutually exclusive")
 	}
 	// fail if doesn't have upstream or redirect and is "enabled"
 	if o.Upstream == nil && o.Redirect == nil {


### PR DESCRIPTION
So this fix focuses on order of checks performed when validating.

So for example we were checking everything even when some where mutually exclusive. Previously we'd check for upstream even when the Path was already disabled. 



Sample API I used for testing:
```
openapi: 3.0.0
servers:
  - url: http://localhost:8080
info:
  title: simple-api
  version: 0.1.0
  description: A simple API example to test Kusk Gateway with
  license:
    name: MIT
    url: https://github.com/kubeshop/kusk-gateway/blob/main/LICENSE
paths:
  /hello:
    x-kusk:
      disabled: true
      upstream:
        service:
          name: hello-world-svc
          namespace: default
          port: 8080
      # mocking:
      #   enabled: true
      # redirect:
      #   scheme_redirect: https
      #   host_redirect: thenewhost.com
      #   response_code: 302
    get:     
      summary: Returns a Hello world to the user
      responses:
        '200':
          description: A simple hello world!
          content:
            application/json; charset=utf-8:
              schema:
                type: object
                properties:
                  message:
                    type: string
                required:
                  - message
          
```

Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>
