### PR TITLE
add ci for packing and pushing choco packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -242,9 +242,6 @@ jobs:
         with:
           strip_v: true
 
-      - name: Use tag
-        run: echo ${{steps.tag.outputs.tag}}
-
       - name: Download newest version
         id: cliDownload
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -228,6 +228,57 @@ jobs:
               "${APTLY_URL}/api/publish/:${REPO_NAME}/linux"
           fi
 
+  build-and-publish-windows-installer:
+    needs: release
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+        with:
+          strip_v: true
+
+      - name: Use tag
+        run: echo ${{steps.tag.outputs.tag}}
+
+      - name: Download newest version
+        id: cliDownload
+        run: |
+          $tag = $env:TAG
+
+          Invoke-Webrequest -UseBasicParsing -URI "https://github.com/kubeshop/kusk-gateway/releases/download/v${tag}/kusk_${tag}_Windows_x86_64.tar.gz" -OutFile kusk.tar.gz
+          $hash = Get-FileHash kusk.tar.gz | Select -ExpandProperty Hash
+
+          #setting set-output function for now since new commands with were not working as expected
+          echo '::echo::on'
+          echo "::set-output name=hash::$hash"
+        env:
+          TAG: ${{steps.tag.outputs.tag}}
+
+      - name: Update choco files
+        run: |
+
+          (Get-Content choco/tools/chocolateyinstall.ps1) -Replace '%checksum%', $env:PACKAGE_CHECKSUM | Set-Content choco/tools/chocolateyinstall.ps1
+          (Get-Content choco/kusk.nuspec) -Replace '%version%', $env:PACKAGE_VERSION | Set-Content choco/kusk.nuspec
+        env:
+          PACKAGE_CHECKSUM: ${{ steps.cliDownload.outputs.hash }}
+          PACKAGE_VERSION: ${{steps.tag.outputs.tag}}
+
+      - name: Pack and release
+        run: |
+          cd choco
+          choco pack
+
+          choco apikey --key  ${{ secrets.COMMOM_CHOCO_API_KEY }} --source ${{ env.COMMOM_CHOCO_REPO }}
+          choco push kusk.$env:PACKAGE_VERSION.nupkg --source ${{ env.COMMOM_CHOCO_REPO }}
+        env:
+          COMMOM_CHOCO_REPO: "https://chocolatey.kubeshop.io/chocolatey"
+          PACKAGE_VERSION: ${{steps.tag.outputs.tag}}
+
   #   This job runs when we have changed_resources from the upstream release job
   notify_slack_if_resources_changed:
     name: "Notify when CRD or RBAC changed"

--- a/choco/kusk.nuspec
+++ b/choco/kusk.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>kusk</id>
+    <version>%version%</version>
+    <title>kusk</title>
+    <authors>Kubeshop</authors>
+    <projectUrl>https://kusk.io</projectUrl>
+    <tags>kusk kubeshop k8s openapi apiops</tags>
+    <summary>Kusk - OpenAPI-driven, developer-centric gateway for modern REST APIs</summary>
+    <description>Kusk - OpenAPI-driven, developer-centric gateway for modern REST APIs</description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'; # stop on all errors
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url64      = "https://github.com/kubeshop/kusk-gateway/releases/download/v${env:chocolateyPackageVersion}/kusk_${env:chocolateyPackageVersion}_Windows_x86_64.tar.gz" # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
+  fileType      = 'exe'
+  url64bit      = $url64
+  softwareName  = 'kusk*'
+
+  # %placeholder% will be replaced by the correct value in the CI pipeline
+  checksum      = '%checksum%'
+  checksumType  = 'sha256'
+
+}
+
+Install-ChocolateyZipPackage @packageArgs
+Get-ChocolateyUnzip -FileFullPath "$toolsDir/kusk_${env:chocolateyPackageVersion}_Windows_x86_64.tar" -Destination $toolsDir

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -50,6 +50,19 @@ sudo apt-get install -y kusk
 go install -x github.com/kubeshop/kusk-gateway/cmd/kusk@latest
 ```
 
+**Windows (Chocolatey)**
+
+Please run the commands  from an elevated command shell.
+1. Add our repository URL to the list of Chocolatey sources:
+```sh
+choco source add --name=kubeshop_repo --source=https://chocolatey.kubeshop.io/chocolatey
+```
+
+2. Install `kusk`:
+```sh
+choco install kusk -y
+```
+
 ### **2. Install Kusk Gateway in your cluster**
 
 Use the Kusk CLIs [install command](./reference/cli/install-cmd.md) to install Kusk Gateway components in your cluster.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -52,7 +52,7 @@ go install -x github.com/kubeshop/kusk-gateway/cmd/kusk@latest
 
 **Windows (Chocolatey)**
 
-Please run the commands  from an elevated command shell.
+Please run the commands from an elevated command shell.
 1. Add our repository URL to the list of Chocolatey sources:
 ```sh
 choco source add --name=kubeshop_repo --source=https://chocolatey.kubeshop.io/chocolatey

--- a/docs/docs/quick-links/install.md
+++ b/docs/docs/quick-links/install.md
@@ -52,8 +52,21 @@ sudo apt-get install -y kusk
 ```
 
 #### Windows
+Install with Chocolatey
 
-For Windows installation you can either download the [latest release binary](https://github.com/kubeshop/kusk-gateway/releases/latest) or use the following command ([`go` binary](https://go.dev/doc/install)  needed):
+Please run the commands from an elevated command shell.
+
+1. Add our repository URL to the list of Chocolatey sources:
+```sh
+choco source add --name=kubeshop_repo --source=https://chocolatey.kubeshop.io/chocolatey
+```
+
+2. Install `kusk`:
+```sh
+choco install kusk -y
+```
+
+For other ways of installation, you can download the [latest release binary](https://github.com/kubeshop/kusk-gateway/releases/latest) or use the following command ([`go` binary](https://go.dev/doc/install)  needed):
 
 ```sh
 go install -x github.com/kubeshop/kusk-gateway/cmd/kusk@latest

--- a/docs/docs/quick-links/upgrade.md
+++ b/docs/docs/quick-links/upgrade.md
@@ -36,8 +36,13 @@ sudo apt-get upgrade -y kusk
 ```
 
 #### Windows
+Chocolatey
 
-For Windows installation you can either download the [latest release binary](https://github.com/kubeshop/kusk-gateway/releases/latest) or use the following command ([`go` binary](https://go.dev/doc/install)  needed):
+Please run the command from an elevated command shell.
+```sh
+choco upgrade kusk -y
+```
+For other ways of installation, you can download the [latest release binary](https://github.com/kubeshop/kusk-gateway/releases/latest) or use the following command ([`go` binary](https://go.dev/doc/install)  needed):
 
 ```sh
 go install -x github.com/kubeshop/kusk-gateway/cmd/kusk@latest


### PR DESCRIPTION
This PR adds a separate job in CI release flow that packs and pushed `kusk` packages to common chocolatey repository.

## Changes
1. Added `chocolateyinstall.ps1` and `nuspec` files for packaging.
2. Updated CI
3. Updated docs.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
