### PR TITLE
42Crunch SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,4 +179,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/cli-runtime v0.25.0
+	moul.io/http2curl v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1338,6 +1338,8 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=
+moul.io/http2curl v1.0.0/go.mod h1:f6cULg+e4Md/oW1cYmwW4IWQOVl2lGbmCNGOHvzX2kE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/crunch42/crunch.go
+++ b/pkg/crunch42/crunch.go
@@ -1,0 +1,196 @@
+package crunch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"moul.io/http2curl"
+)
+
+const baseURL = "https://platform.42crunch.com/api/v1/"
+
+const debug = "CRUNCH_DEBUG"
+
+type Collection struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	IsShared      bool   `json:"isShared"`
+	IsSharedWrite bool   `json:"isSharedWrite"`
+}
+
+type Client struct {
+	client  *http.Client
+	apiKey  string
+	baseURL *url.URL
+}
+
+func NewClient(apiKey string, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	url, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	client := &Client{
+		apiKey:  apiKey,
+		baseURL: url,
+		client:  httpClient,
+	}
+
+	return client, nil
+}
+
+func (c *Client) DoRequest(method, path string, body, v interface{}) (*ErrorResponse, error) {
+	req, err := c.NewRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req, v)
+}
+
+func (c *Client) NewRequest(method, path string, body interface{}) (*http.Request, error) {
+	// relative path to append to the endpoint url, no leading slash please
+	if path[0] == '/' {
+		path = path[1:]
+	}
+	rel, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.baseURL.ResolveReference(rel)
+	var req *http.Request
+	if body != nil {
+		bodyBytes, _ := json.Marshal(body)
+		req, _ = http.NewRequest(method, u.String(), bytes.NewBuffer(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, _ = http.NewRequest(method, u.String(), nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	req.Close = true
+
+	if _, ok := os.LookupEnv("CRUNCH_DEBUG"); ok {
+		command, _ := http2curl.GetCurlCommand(req)
+		fmt.Println(command)
+	}
+	req.Header.Add("X-API-KEY", c.apiKey)
+	return req, nil
+}
+
+func (c *Client) Do(req *http.Request, v interface{}) (*ErrorResponse, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode > 299 {
+		o, _ := io.ReadAll(resp.Body)
+		errResp := &ErrorResponse{
+			StatusCode: resp.StatusCode,
+			Errors:     string(o),
+		}
+
+		return errResp, fmt.Errorf("%s returned %d", req.URL, resp.StatusCode)
+	}
+
+	o, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := os.LookupEnv("CRUNCH_DEBUG"); ok {
+		fmt.Println("Response body:", string(o))
+	}
+	err = json.Unmarshal(o, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, err
+}
+
+type ErrorResponse struct {
+	StatusCode int
+	Errors     string
+}
+
+func (c *Client) GetCollection(id string) (*Item, *ErrorResponse, error) {
+
+	collection := &Item{}
+
+	path := fmt.Sprintf("%s/collections/%s", c.baseURL, id)
+	resp, err := c.DoRequest("GET", path, nil, collection)
+	if err != nil {
+		return nil, resp, err
+
+	}
+	return collection, resp, err
+}
+func (c *Client) ListCollections() (*Collections, *ErrorResponse, error) {
+	collections := &Collections{}
+
+	path := fmt.Sprintf("%s/collections", c.baseURL)
+	resp, err := c.DoRequest("GET", path, nil, collections)
+	if err != nil {
+		return nil, resp, err
+
+	}
+	return collections, resp, err
+}
+
+func (c *Client) CreateCollection(collection *Collection) (*Item, *ErrorResponse, error) {
+
+	toReturn := &Item{}
+	path := fmt.Sprintf("%s/collections", c.baseURL)
+	resp, err := c.DoRequest("POST", path, collection, toReturn)
+	if err != nil {
+		return nil, resp, err
+
+	}
+	return toReturn, resp, err
+}
+
+func (c *Client) CreateAPI(api *API) (*API, *ErrorResponse, error) {
+	path := fmt.Sprintf("%s/apis", c.baseURL)
+	resp, err := c.DoRequest("POST", path, api, api)
+	if err != nil {
+		return nil, resp, err
+
+	}
+	return api, resp, err
+}
+
+type API struct {
+	CollectionID string    `json:"cid"`
+	Name         string    `json:"name"`
+	OAS          **os.File `json:"specfile"`
+	IsYaml       bool      `json:"yaml"`
+}
+
+type Collections struct {
+	List []Item `json:"list"`
+}
+
+type Item struct {
+	Desc CollectionDescription `json:"desc"`
+}
+type CollectionDescription struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	TechnicalName string `json:"technicalName"`
+	Source        string `json:"source"`
+	IsShared      bool   `json:"isShared"`
+	IsSharedWrite bool   `json:"isSharedWrite"`
+}

--- a/pkg/crunch42/crunch_test.go
+++ b/pkg/crunch42/crunch_test.go
@@ -1,0 +1,75 @@
+package crunch
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var apiKey = ""
+var c *Client
+var collID = ""
+
+func shouldSkip() bool {
+	val, ok := os.LookupEnv("CRUNCH42")
+	apiKey = val
+
+	var err error
+	c, err = NewClient(apiKey, nil)
+	if err != nil {
+		fmt.Println(err)
+		return true
+	}
+	return !ok
+}
+
+func TestCreateCollection(t *testing.T) {
+	if shouldSkip() {
+		t.Skip("skip test") // remove to run test
+	}
+
+	col, _, err := c.CreateCollection(&Collection{
+		Name: "test",
+	})
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	collID = col.Desc.ID
+	fmt.Println("collID", collID)
+
+}
+
+func TestListCollections(t *testing.T) {
+	if shouldSkip() {
+		t.Skip("skip test") // remove to run test
+	}
+
+	col, _, err := c.ListCollections()
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	fmt.Println(col.List[0].Desc.Name)
+}
+
+func TestGetCollection(t *testing.T) {
+	fmt.Println("collID", collID)
+	if shouldSkip() {
+		t.Skip("skip test") // remove to run test
+	}
+
+	col, _, err := c.GetCollection(collID)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+		return
+	}
+
+	if col.Desc.ID != collID {
+		t.Log("Retrieved ID isn't the same as expected")
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>

Unblocks #974 

This is first run at the 42Crunch SDK.

According to 42Crunch API Specs 
```
    "/api/v1/apis": {
      "post": {
        "tags": [
          "ApiManager"
        ],
        "summary": "Create API V1",
        "description": "In order to create an API, you must specify a collection ID, a display name and an OAS specfile. Note that this name is not used as the API ID, a UUID is generated instead. You must use this UUID to work with APIs.\nYAML input is not supported. YAML files must be converted to JSON prior to import.\n",
        "operationId": "CreateAPI",
        "requestBody": {
          "content": {
            "multipart/form-data": {
              "schema": {
                "type": "object",
                "properties": {
                  "cid": {
                    "type": "string",
                    "maxLength": 36,
                    "minLength": 36,
                    "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
                    "description": "CollectionID",
                    "format": "uuid",
                    "readOnly": true
                  },
                  "name": {
                    "type": "string",
                    "maxLength": 512,
                    "pattern": "^[a-zA-Z0-9_\\-\\.]+$",
                    "description": "API Display Name",
                    "minLength": 1,
                    "example": "MySampleAPI"
                  },
                  "specfile": {
                    "type": "string",
                    "description": "Raw OAS file in JSON format - YAML is not supported",
                    "format": "binary"
                  },
                  "yaml": {
                    "type": "boolean",
                    "description": "Set to true to view OAS as YAML on the SaaS UI",
                    "default": false
                  }
                },
                "required": [
                  "cid",
                  "name",
                  "specfile"
                ]
              },
              "examples": {}
            }
          }
        },
``` 

In order to add an API for 42Crunch assessment API Collection must be referenced  i.e. so we need to either create one for the user or use existing one. Voting in favor of the former option.

To test this environment variable CRUNCH42 must be set with the value of API Token which can be found in their control panel
Also in order to debug what's going on in the SDK environment variable `CRUNCH_DEBUG` can be used 
For example:
```
CRUNCH42=[my_token] CRUNCH_DEBUG=true go test -v
```
