### PR TITLE
remove port selection from kusk gateway add

### DIFF
--- a/cmd/kusk/cmd/add_gateway.go
+++ b/cmd/kusk/cmd/add_gateway.go
@@ -44,7 +44,6 @@ import (
 var (
 	gatewayName      string
 	svcType          string
-	port             string
 	defaultGateway   bool
 	gatewayNamespace string
 )
@@ -61,16 +60,6 @@ var addGatewayCMD = &cobra.Command{
 		if len(svcType) > 0 {
 			if svcType != "ClusterIP" && svcType != "LoadBalancer" {
 				return fmt.Errorf("svcType values can only be ClusterIP or LoadBalancer")
-			}
-		}
-		if len(port) > 0 {
-			pport, err := strconv.Atoi(port)
-			if err != nil {
-				return fmt.Errorf("port value must be an integer")
-			}
-
-			if pport > 65535 {
-				return fmt.Errorf("port number cannot be higher than 65535")
 			}
 		}
 
@@ -108,7 +97,6 @@ func init() {
 
 	addGatewayCMD.Flags().StringVarP(&gatewayNamespace, "namespace", "n", "", "namespace where the new gateway will be created")
 	addGatewayCMD.Flags().StringVarP(&svcType, "serviceType", "s", "", "Service type of the gateway. Supported options LoadBalancer, ClusterIP")
-	addGatewayCMD.Flags().StringVarP(&port, "port", "p", "", "port for the gateway. Supported values are from 0 to 65536")
 	addGatewayCMD.Flags().StringVarP(&gatewayName, "name", "", "", "name of the gateway")
 	addGatewayCMD.Flags().BoolVarP(&defaultGateway, "default", "", false, "Indicates if the geteway is the default gateway in the cluster")
 }
@@ -188,17 +176,9 @@ func addRun(cmd *cobra.Command, args []string) error {
 		Type: corev1.ServiceType(svcType),
 	}
 
-	if len(port) == 0 {
-		port, err = portPrompt.Run()
-		if err != nil {
-			return err
-		}
-	}
-
-	svcPort, _ := strconv.Atoi(port)
 	fleet.Spec.Service.Ports = []corev1.ServicePort{
 		{
-			Port: int32(svcPort),
+			Port: 80,
 		},
 	}
 
@@ -222,38 +202,4 @@ var serviceTypePrompt = promptui.Select{
 
 var namePrompt = promptui.Prompt{
 	Label: "Please input name for the new gateway instance",
-}
-
-var portPrompt = promptui.Prompt{
-	Label:    "Input desired service port",
-	Validate: validatePort,
-}
-
-func validatePort(input string) error {
-	pport, err := strconv.Atoi(input)
-	if err != nil {
-		return err
-	}
-	if pport > 65535 {
-		return fmt.Errorf("port number cannot be higher than 65535")
-	}
-	c, err := utils.GetK8sClient()
-	if err != nil {
-		return err
-	}
-	services := corev1.ServiceList{}
-	if err := c.List(context.Background(), &services, &client.ListOptions{}); err != nil {
-		return err
-	}
-
-	for _, svc := range services.Items {
-		if svc.Spec.Type == "LoadBalancer" {
-			for _, p := range svc.Spec.Ports {
-				if p.Port == int32(pport) {
-					return fmt.Errorf("port %d already taken, please choose different one", pport)
-				}
-			}
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
The port selection was introduced bc it was tested in a bare metal server with 1 IP address. This use case should not be supported because every gateway (envoy fleet) needs to have a unique IP address, which cloud providers like civo, gke and eks support by default

this will help me finish an article on StaticRoute

Signed-off-by: Abdallah Abedraba <aabedraba@gmail.com>

This PR...

## Changes

-

## Fixes

-

## Checklist

- [ x ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
