### PR TITLE
Fetch IP of named envoyfleet by providing --envoyfleet.name and --envoyfleet.namespace flag values

### DIFF
--- a/cmd/kusk/cmd/ip.go
+++ b/cmd/kusk/cmd/ip.go
@@ -72,7 +72,7 @@ var ipCmd = &cobra.Command{
 			return
 		}
 
-		envoyFleet := &kuskv1.EnvoyFleet{}
+		var envoyFleet *kuskv1.EnvoyFleet
 		if ipEnvoyFleetName != "" {
 			envoyFleet, err = getNamedEnvoyFleet(cmd.Context(), ipEnvoyFleetName, ipEnvoyFleetNamespace, k8sclient)
 		} else {


### PR DESCRIPTION
This PR closes #968 

If no flags are provided, the IP of the default fleet is returned
If the `--envoyfleet.name` flag is provided, it will attempt to fetch the IP of that fleet in the `kusk-system` namespace
if both `--envoyfleet.name` and `--envoyfleet.namespace` flags are provided, it will attempt to fetch the IP of that fleet in the provided namespace namespace

