### PR TITLE
Kusk uninstall fix

### DIFF
--- a/cmd/kusk/cmd/uninstall.go
+++ b/cmd/kusk/cmd/uninstall.go
@@ -101,7 +101,19 @@ var uninstallCmd = &cobra.Command{
 				}
 				apiSpinner.Success("Deleted APIs")
 			}
-
+			for {
+				if err := c.List(cmd.Context(), apis, &client.ListOptions{}); err != nil {
+					if err.Error() == `no matches for kind "API" in version "gateway.kusk.io/v1alpha1"` {
+						kuskui.PrintInfo("Kusk Custom Resource Definition API is not installed.")
+					} else {
+						reportError(err)
+						return err
+					}
+				}
+				if len(apis.Items) == 0 {
+					break
+				}
+			}
 			fleets := &kuskv1.EnvoyFleetList{}
 			if err := c.List(cmd.Context(), fleets, &client.ListOptions{}); err != nil {
 				if err.Error() == `no matches for kind "EnvoyFleet" in version "gateway.kusk.io/v1alpha1"` {
@@ -123,6 +135,19 @@ var uninstallCmd = &cobra.Command{
 				envoyFleetSpinner.Success("Deleted EnvoyFleets")
 			}
 
+			for {
+				if err := c.List(cmd.Context(), fleets, &client.ListOptions{}); err != nil {
+					if err.Error() == `no matches for kind "EnvoyFleet" in version "gateway.kusk.io/v1alpha1"` {
+						kuskui.PrintInfo("Kusk Custom Resource Definition EnvoyFleet is not installed.")
+					} else {
+						reportError(err)
+						return err
+					}
+				}
+				if len(fleets.Items) == 0 {
+					break
+				}
+			}
 			staticRoutes := &kuskv1.StaticRouteList{}
 			if err := c.List(cmd.Context(), staticRoutes, &client.ListOptions{}); err != nil {
 				if err.Error() == `no matches for kind "StaticRoute" in version "gateway.kusk.io/v1alpha1"` {
@@ -142,6 +167,20 @@ var uninstallCmd = &cobra.Command{
 					}
 				}
 				staticRoutesSpinner.Success("Deleted StaticRoutes")
+			}
+
+			for {
+				if err := c.List(cmd.Context(), staticRoutes, &client.ListOptions{}); err != nil {
+					if err.Error() == `no matches for kind "StaticRoute" in version "gateway.kusk.io/v1alpha1"` {
+						kuskui.PrintInfo("Kusk Custom Resource Definition StaticRouote is not installed")
+					} else {
+						reportError(err)
+						return err
+					}
+				}
+				if len(staticRoutes.Items) == 0 {
+					break
+				}
 			}
 
 			kuskGatewaySpinner := utils.NewSpinner("Deleting Kusk Gateway...")

--- a/cmd/kusk/cmd/uninstall.go
+++ b/cmd/kusk/cmd/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	kuskv1 "github.com/kubeshop/kusk-gateway/api/v1alpha1"
 	"github.com/kubeshop/kusk-gateway/cmd/kusk/internal/errors"
@@ -113,7 +114,9 @@ var uninstallCmd = &cobra.Command{
 				if len(apis.Items) == 0 {
 					break
 				}
+				time.Sleep(1 * time.Second)
 			}
+
 			fleets := &kuskv1.EnvoyFleetList{}
 			if err := c.List(cmd.Context(), fleets, &client.ListOptions{}); err != nil {
 				if err.Error() == `no matches for kind "EnvoyFleet" in version "gateway.kusk.io/v1alpha1"` {
@@ -147,7 +150,9 @@ var uninstallCmd = &cobra.Command{
 				if len(fleets.Items) == 0 {
 					break
 				}
+				time.Sleep(1 * time.Second)
 			}
+
 			staticRoutes := &kuskv1.StaticRouteList{}
 			if err := c.List(cmd.Context(), staticRoutes, &client.ListOptions{}); err != nil {
 				if err.Error() == `no matches for kind "StaticRoute" in version "gateway.kusk.io/v1alpha1"` {
@@ -181,6 +186,7 @@ var uninstallCmd = &cobra.Command{
 				if len(staticRoutes.Items) == 0 {
 					break
 				}
+				time.Sleep(1 * time.Second)
 			}
 
 			kuskGatewaySpinner := utils.NewSpinner("Deleting Kusk Gateway...")


### PR DESCRIPTION
When trying to uninstall kusk from the cluster the uninstaller would hang forever causing this:
```
  NamespaceFinalizersRemaining                 True    Wed, 14 Dec 2022 09:13:23 +0000  SomeFinalizersRemain  Some content in the namespace has finalizers remaining: gateway.kusk.io/apifinalizer in 1 resource instances, gateway.kusk.io/srfinalizer in 2 resource instances
```

This PR ensures for Kusk CRs to be removed first before moving to delete kusk-system components
Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>
